### PR TITLE
Add the modernised heritage corpus (21 documents)

### DIFF
--- a/sources/a/document.adoc
+++ b/sources/a/document.adoc
@@ -1,0 +1,24 @@
+= X
+A
+:doctype: internet-draft
+:name: draft-killer-rabbit-00
+:status: informational
+:fullname: A
+:surname: A
+:revdate: 2017-11-03
+
+== Introduction
+
+The *Killer Rabbit of Caerbannog*, that most formidable foe of
+the Knights and of all that is holy or carrot-like, has been
+depicted diversely in lay and in song. We venture to say,
+_contra_ the claim made in <<RFC8140,of,section=4.1>>,
+that the Killer Rabbit of Caerbannog truly is the most afeared
+of all the creatures. Short of sanctified ordnance such as
+<<holy_hand_grenade,format=title>>, there are few remedies
+known against its awful lapine powers.
+
+[[holy_hand_grenade]]
+[bibliography]
+== Normative references
+* [[[RFC8140,RFC 8140]]], _X_

--- a/sources/a/document.adoc
+++ b/sources/a/document.adoc
@@ -3,6 +3,7 @@ A
 :doctype: internet-draft
 :name: draft-killer-rabbit-00
 :status: informational
+:intended-series: informational
 :fullname: A
 :surname: A
 :revdate: 2017-11-03

--- a/sources/biblio-insert-v2/document.adoc
+++ b/sources/biblio-insert-v2/document.adoc
@@ -1,0 +1,33 @@
+= The Holy Hand Grenade of Antioch
+Arthur Pendragon
+:doctype: internet-draft
+:workgroup: silly
+:fullname: Arthur Pendragon
+:surname: Pendragon
+:givenname: Arthur
+
+[[xyz]]
+== Hello
+Hello
+
+* a <<RFC2119,2.3 of: See internet draft subsection>>
+* b <<I-D.abarth-cake>>
+* c <<xyz,format=counter: xyzzy>>
+* d <<biblio>>
+* e <<AsciiDoc,AsciiDoctor>>
+
+
+[[biblio]]
+=== Biblio
+See biblio
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[AsciiDoc]]] Rackham, S., "AsciiDoc: Text based document generation", http://www.methods.co.nz/asciidoc/, November 2013.
+
+[bibliography]
+== Informative References
+
+* [[[I-D.abarth-cake,I-D.abarth-cake]]]

--- a/sources/biblio-insert-v3/document.adoc
+++ b/sources/biblio-insert-v3/document.adoc
@@ -1,0 +1,35 @@
+= The Holy Hand Grenade of Antioch
+Arthur Pendragon
+:doctype: internet-draft
+:workgroup: silly
+:fullname: Arthur Pendragon
+:surname: Pendragon
+:givenname: Arthur
+
+[[xyz]]
+== Hello
+Hello
+
+* a <<RFC2119,2.3 of: See internet draft subsection>>
+* b <<I-D.abarth-cake>>
+* c <<xyz,format=counter: xyzzy>>
+* d <<biblio>>
+* e <<AsciiDoc,AsciiDoctor>>
+* f <<mathrefs>>
+
+
+[[biblio]]
+=== Biblio
+See biblio
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[AsciiDoc]]] Rackham, S., "AsciiDoc: Text based document generation", http://www.methods.co.nz/asciidoc/, November 2013.
+
+[bibliography]
+== Informative References
+
+* [[[I-D.abarth-cake,I-D.abarth-cake]]]
+* [[[mathrefs]]] "AsciiMath (http://asciimath.org) and MathJax (https://www.mathjax.org)", November 2017.

--- a/sources/davies-template/document.adoc
+++ b/sources/davies-template/document.adoc
@@ -4,6 +4,7 @@ Elwyn Davies <elwynd@dial.pipex.com>
 :name: draft-ietf-xml2rfc-template-06
 :ipr: trust200902
 :status: info
+:intended-series: informational
 :abbrev: Abbreviated Title
 :fullname: Elwyn Davies
 :surname: Davies

--- a/sources/davies-template/document.adoc
+++ b/sources/davies-template/document.adoc
@@ -1,0 +1,265 @@
+= Put Your Internet Draft Title Here
+Elwyn Davies <elwynd@dial.pipex.com>
+:doctype: internet-draft
+:name: draft-ietf-xml2rfc-template-06
+:ipr: trust200902
+:status: info
+:abbrev: Abbreviated Title
+:fullname: Elwyn Davies
+:surname: Davies
+:givenname: Elwyn
+:initials: E.B.
+:role: editor
+:organization: Folly Consulting
+:city: Soham
+:country: UK
+:phone: +44 7889 488 335
+:email: elwynd@dial.pipex.com
+:revdate: 2010-04-01
+:area: General
+:workgroup: Internet Engineering Task Force
+:keyword: template
+:inline-definition-lists: true
+:compact: yes
+:subcompact: no
+:rfc2629xslt: true
+
+Insert an abstract: MANDATORY. This template is for creating an
+Internet Draft.
+
+== Introduction
+
+The original specification of xml2rfc format is in <<RFC2629,RFC 2629>>.
+
+=== Requirements Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119,RFC 2119>>.
+
+[[simple_list]]
+== Simple List
+
+List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
+'format'.
+
+* First bullet
+
+* Second bullet
+
+You can write text here as well.
+//[Note: Asciidoc will force new paragraph]
+
+== Figures
+
+Figures should not exceed 69 characters wide to allow for the indent
+of sections.
+
+[[xml_happy]]
+[align=center]
+====
+Preamble text - can be omitted or empty.
+
+[align=left]
+....
++-----------------------+
+| Use XML, be Happy :-) |
+|_______________________|
+....
+
+Cross-references allowed in pre- and postamble. <<min_ref>>.
+====
+
+The CDATA means you don't need to escape meta-characters (especially
+< (\&lt;) and & (\&amp;)) but is not essential.
+Figures may also have a title attribute but it won't be displayed unless
+there is also an anchor. White space, both horizontal and vertical, is
+significant in figures even if you don't use CDATA.
+
+== Subsections and Tables
+
+=== A Subsection
+
+By default 3 levels of nesting show in table of contents but that
+can be adjusted with the value of the "tocdepth" processing
+instruction.
+
+=== Tables
+
+pass:[..] are very similar to figures:
+
+//[Note: Asciidoc does not support preambles and postambles within tables.]
+
+Tables use ttcol to define column headers and widths. Every cell then has a "c" element for its content.
+
+[[table_example]]
+.A Very Simple Table
+[cols="2*^", frame="sides", grid="cols"]
+|===
+|ttcol #1 |ttcol #2
+
+|c #1 |c #2
+|c #3 |c #4
+|c #5 |c #6
+|===
+
+which is a very simple example.
+
+[[nested_lists]]
+== More about Lists
+Lists with 'hanging labels': the list item is indented the amount of
+the hangIndent:
+
+[hang-indent=8]
+short:: With a label shorter than the hangIndent.
+
+fantastically long label:: With a label longer than the hangIndent.
+
+vspace_trick:: {blank} +
+Forces the new item to start on a new line.
+
+Simulating more than one paragraph in a list item using
+<vspace>:
+
+[loweralpha]
+. First, a short item.
+
+. Second, a longer list item.
++
+{blank}
++
+And something that looks like a separate pararaph..
+
+NOTE: In Asciidoc, it *is* a separate paragraph.
+
+Simple indented paragraph using the "empty" style:
+
+[empty,hang-indent=8]
+* The quick, brown fox jumped over the lazy dog and lived to fool
+         many another hunter in the great wood in the west.
+
+
+=== Numbering Lists across Lists and Sections
+Numbering items continuously although they are in separate
+<list> elements, maybe in separate sections using the "format"
+style and a "counter" variable.
+
+First list:
+
+[hang-indent=4,counter=reqs,format=R%d]
+. #1
+
+. #2
+
+. #3
+
+Specify the indent explicitly so that all the items line up
+nicely.
+
+Second list:
+[hang-indent=4,counter=reqs,format=R%d]
+. #4
+
+. #5
+
+. #6
+
+=== Where the List Numbering Continues
+List continues here.
+
+Third list:
+[hang-indent=4,counter=reqs,format=R%d]
+. #7
+
+. #8
+
+. #9
+
+. #10
+
+The end of the list.
+
+[[codeExample]]
+== Example of Code or MIB Module To Be Extracted
+
+// NOTE: in asciidoctor-rfc output we're missing an empty line before
+// the code block and after it. Can't figure out a way to create that...
+
+====
+The <artwork> element has a number of extra attributes
+that can be used to substitute a more aesthetically pleasing rendition
+into HTML output while continuing to use the ASCII art version in the
+text and nroff outputs (see the xml2rfc README for details). It also
+has a "type" attribute. This is currently ignored except in the case
+'type="abnf"'. In this case the "artwork" is expected to contain a
+piece of valid Augmented Backus-Naur Format (ABNF) grammar. This will
+be syntax checked by xml2rfc and any errors will cause a fatal error
+if the "strict" processing instruction is set to "yes". The ABNF will
+also be colorized in HTML output to highlight the syntactic
+components. Checking of additional "types" may be provided in future
+versions of xml2rfc.
+
+----
+
+/**** an example C program */
+
+#include <stdio.h>
+
+void
+main(int argc, char *argv[])
+{
+   int i;
+
+   printf("program arguments are:\n");
+   for (i = 0; i < argc; i++) {
+       printf("%d: \"%s\"\n", i, argv[i]);
+   }
+
+   exit(0);
+} /* main */
+
+/* end of file */
+
+----
+====
+
+[[Acknowledgements]]
+== Acknowledgements
+This template was derived from an initial version written by Pekka Savola and contributed by him to the xml2rfc project.
+
+This document is part of a plan to make xml2rfc indispensable <<DOMINATION>>.
+
+[[IANA]]
+== IANA Considerations
+This memo includes no request to IANA.
+
+All drafts are required to have an IANA considerations section (see
+<<RFC5226,Guidelines for Writing an IANA Considerations Section in RFCs>> for a guide). If the draft does not require IANA to do
+anything, the section contains an explicit statement that this is the
+case (as above). If there are no requirements for IANA, the section will
+be removed during conversion into an RFC by the RFC Editor.
+
+[[Security]]
+== Security Considerations
+All drafts are required to have a security considerations section.
+See <<RFC3552,RFC 3552>> for a guide.
+
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[min_ref]]] authSurName, authInitials, "Minimal Reference", 2006.
+
+[bibliography]
+== Informative References
+
+* [[[RFC2629,RFC 2629]]]
+* [[[RFC3552,RFC 3552]]]
+* [[[RFC5226,RFC 5226]]]
+* [[[DOMINATION]]] Mad Dominators, Inc., "Ultimate Plan for Taking Over the World", http://www.example.com/dominator.html, 1984.
+
+[[app-additional]]
+[appendix]
+== Additional Stuff
+This becomes an Appendix.

--- a/sources/draft-iab-html-rfc-bis/document.adoc
+++ b/sources/draft-iab-html-rfc-bis/document.adoc
@@ -1,0 +1,2007 @@
+= HTML Format for RFCs
+Joe Hildebrand <joe-ietf@cursive.net>; Paul Hoffman <paul.hoffman@icann.org>
+:rfc2629xslt: true
+:toc-include: yes
+:toc-depth: 4
+:sort-refs: yes
+:sym-refs: yes
+:compact: yes
+:subcompact: no
+:consensus: yes
+:ipr: trust200902
+:doctype: rfc
+:submission-type: IAB
+:name: 7992
+:docnumber: 7992
+:status: informational
+:abbrev: HTML for RFCs
+:fullname: Joe Hildebrand
+:surname: Hildebrand
+:givenname: Joe
+:initials: J.
+:role: editor
+:organization: Mozilla
+:email: joe-ietf@cursive.net
+:fullname_2: Paul Hoffman
+:surname_2: Hoffman
+:givenname_2: Paul
+:initials_2: P.
+:organization_2: ICANN
+:email_2: paul.hoffman@icann.org
+:revdate: 2016-12
+:keyword: html,css,rfc
+
+In order to meet the evolving needs of the Internet community, the
+canonical format for RFCs is changing from a plain-text, ASCII-only format to an
+XML format that will, in turn, be rendered into several
+publication formats. This document defines the HTML format that will
+be rendered for an RFC or Internet-Draft.
+
+[#introduction]
+== Introduction
+
+As described in <<RFC7990>>, the RFC
+Series is changing. One of those changes includes the RFC Editor
+publishing a non-canonical HTML version of RFCs.
+
+This document describes the HTML format that will be used as one of the
+publication formats for the RFC Series. It defines a strict subset of
+HTML appropriate for RFC Series documents.  The visual layout of the
+document will be defined through a cascading style sheet (CSS)
+<<W3C.REC-CSS2-20110607>>.  The CSS will be included in the
+HTML file but will be described in <<RFC7993>>.
+
+The details (particularly any vocabularies) described in this document
+are expected to change based on experience gained in implementing the
+the new publication toolsets. Revised documents will be published
+capturing those changes as the toolsets are completed. Other implementers
+must not expect those changes to remain backwards compatible with the
+details described in this document.
+
+[#requirements-for-html]
+== Requirements for the HTML Format
+
+This section lists the design requirements used to create the HTML
+format described in this document.  These requirements build on those
+found in <<RFC6949>>. Many of these requirements are
+naturally fulfilled by using the output of the preparation tool
+<<RFC7998>>.
+
+
+* The HTML has to render correctly on a list of browser versions that
+the RFC Editor will keep up to date outside of this document.
+* The format will consist of a subset of HTML deemed to be widely
+implemented   by common browsers at the time the specification is
+created, likely to continue to be widely implemented, and unlikely to
+cause security issues.  This will maximize the chances that future HTML
+renderers (such as new web browsers) will continue to produce readable
+text from the HTML format without the format needing to be changed
+frequently.
+* These requirements are expected to change in the future to reflect the
+expectation that HTML rendering will be required for current versions of
+browsers and platforms, while ideally continuing to render correctly on
+recent versions of those browsers.
+* The HTML documents from the RFC Editor or Internet-Drafts directory
+may be re-rendered from the canonical XML format in
+the future to ensure the ongoing readability of the documents.  The
+intent is that any re-rendering would be due to exceptional
+circumstances rather than for minor annoyances.
+* The HTML must display adequately in at least one text-based browser.
+Some consumers of the RFC Series can only access the documents on
+text-based terminals.
+* The HTML document will be self-contained, without requiring external
+files for images, CSS, JavaScript, or the like.  This will allow
+the HTML file to be moved over various non-HTTP transports (such as
+email, FTP, and rsync) without breakage.
+* JavaScript will be supported on a limited basis.  It will not be
+permitted to overwrite or change any text present in the rendered HTML.
+It may, on a limited basis, add additional text that provides
+post-publication metadata or pointers if warranted.  All such text will
+be clearly marked as additional.
+* The HTML document will allow easy local override of the default CSS
+formatting.  This will allow users who have a different visual style
+that they prefer to make RFCs display with that style without having to
+alter the contents of the HTML document.  This might also be valuable
+for allowing people with specific accessibility needs to use a
+customized CSS.
+* HTML tags in documents will rarely have attributes whose only purpose
+is to affect the rendered styling, and those will only be used if it
+would not be possible to specify that styling in a CSS.  No such attributes are known at this time.
+* Both user-defined and auto-generated anchors must be supported and
+linkable, with user-defined anchors appearing in an "id" attribute.
+Auto-generated anchors will be generated for every heading, paragraph,
+and so on, not just those that do not have user-defined anchors.
+User-defined anchors may, and auto-generated anchors will, appear next to
+paragraphs, figures, tables, blockquotes, and section titles.
+* All sections, subsections, figures, and paragraphs should have stable
+numbered link anchors.  Additionally, anchors expressed in the source
+XML should be exposed as anchors in the HTML output as well.
+* The HTML must make it easy to separate sections along with all of their
+subsections into separate files.  This will make creating EPUB
+documents easier in the future.
+* The HTML produced for Internet-Drafts will differ from that produced
+by the RFC Editor due to differences in the output from the prep tool.
+* The abstract must be marked up or tagged in a way that popular search
+engines will extract it as a summary.
+
+[#accessibility]
+=== Requirements for Accessibility
+
+
+* Normative information must be easily accessible to the following
+consumers:
+** People with impaired vision, including those that use large fonts
+and those that use screen readers
+** People with difficulty distinguishing between colors
+** People who use devices with small screens, such as cell phones
+* Specific instances where goals for accessibility are important in the
+design choices of the format have been called out in the text.
+* Note: designing for these consumers does not preclude the use of
+features they cannot use, but it does require that key semantic data not
+be lost when read using the tools and settings that are required by a given
+constituency.
+
+
+[#html5]
+== HTML Version
+
+The RFC Editor will periodically determine which version of the
+HTML specification will be referenced for tools generating the
+format defined in this document.  The starting version will be that
+defined in <<W3C.REC-html5-20141028>>, commonly known as
+"HTML5".  Although the HTML specification mandates several of the syntax
+and structure rules described in this document, they are called out here
+for emphasis.
+
+[#syntax]
+== HTML Syntax
+
+The processor emitting HTML from the XML source will follow these
+rules:
+
+* The HTML output is encoded as UTF-8, as specified in
+<<RFC3629>>.
+* The document is valid HTML.
+* Double quotes (U+0022 QUOTATION MARK: ") are used to quote attribute
+values unless the HTML specification forbids quoting a particular
+attribute.
+* Each logical line is terminated solely with a \n (U+000A: LINE
+FEED), otherwise known as "Unix-style" line endings.
+* Code points below (U+0020: SPACE) or character entity references
+that generate them (e.g. &amp;#9;), other than (U+000A: LINE FEED)
+may not be used.  Note: this rule explicitly forbids \t (U+0009:
+CHARACTER TABULATION), \f (U+000C: FORM FEED), and \r (U+000D:
+CARRIAGE RETURN) from appearing in the HTML output.
+* Comments in the source XML, if any, will not be copied into
+the HTML.
+* The HTML output will be pretty-printed, using whatever
+consistent rules are deemed best by the developers of the HTML
+production tools.
+
+
+Note: none of these rules affect the rendered output of the HTML, but they 
+are intended to increase the chance that text comparison tools
+(e.g., "diff") that operate on the HTML output are easier to write.
+
+[#common]
+== Common Items
+
+This section lists items that are common across multiple parts of the HTML
+document.
+
+[#ids]
+=== IDs
+
+HTML elements that are generated from XML elements that include
+an "anchor" attribute will use the value of the "anchor" attribute
+as the value of the "id" attribute of the corresponding HTML element.
+The prep tool produces XML with "anchor" attributes in all elements that need them.
+Some HTML constructs (such as
+&lt;section&gt;) will use
+multiple instances of these identifiers.
+
+[#pilcrows]
+=== Pilcrows
+
+Each paragraph, artwork, or sourcecode segment outside of a
+&lt;figure&gt; or &lt;table&gt; element will be appended with a
+space and a "pilcrow" (U+00B6: PILCROW SIGN), otherwise known as a
+"paragraph sign".  For the purposes of clarity in ASCII renderings
+of this document, in this document pilcrows are rendered as
+"&amp;para;".  The pilcrow will be linked to the "id" attribute on the
+XML entity to which it is associated using an &lt;a&gt; element of
+class "pilcrow".  For example:
+
+....
+<p id="s-1.1-1">
+  Some paragraph text. <a class="pilcrow" href="#s-1.1-1">&para;</a>
+</p>
+....
+
+The pilcrow will normally be invisible unless the element it is
+attached to is moused over.  The pilcrow will be surrounded by a
+link that points to the element it is attached to.
+
+Pilcrows are never included inside a &lt;table&gt; or
+&lt;figure&gt; element, since the figure number or table number
+serves as an adequate link target.
+
+Elements that might otherwise contain a pilcrow do not get marked
+with a pilcrow if they contain one or more child elements that are
+marked with a pilcrow. For example:
+
+....
+<blockquote id="s-1.2-1">
+  <p id="s-1.2-2">Four score and seven years ago our fathers brought
+    forth on this continent, a new nation, conceived in Liberty, and
+    dedicated to the proposition that all men are created equal.
+    <a href="#s-1.2-2" class="pilcrow">&para;</a></p>
+  <!-- NO pilcrow here -->
+</blockquote>
+....
+
+[#front-matter]
+== Front Matter
+
+The front matter of the HTML format contains processing information,
+metadata of various types, and styling information that applies to the
+document as a whole.  This section describes HTML that is not
+necessarily a direct transform from the XML format.  For more details
+on each of the tags that generate content in this section,
+see <<elements>>.
+
+[#doctype]
+=== DOCTYPE
+
+The DOCTYPE of the document is "html", which declares that the
+document is compliant with HTML5.  The document will start with
+exactly this string:
+
+....
+<!DOCTYPE html>
+....
+
+[#root-element]
+=== Root Element
+
+The root element of the document is &lt;html&gt;.  This element
+includes a &quot;lang&quot; attribute, whose value is a language tag, as discussed in <<RFC5646>>,
+that describes the natural language of the document.  The
+language tag to be included is "en".  The class of the &lt;html&gt;
+element will be copied verbatim from the XML &lt;rfc&gt; element's
+&lt;front&gt; element's &lt;seriesInfo&gt; element's "name"
+attributes (separated by spaces; see Section 2.47.3 of <<RFC7991>>), allowing CSS to style RFCs and
+Internet-Drafts differently from one another (if needed):
+
+....
+<html lang="en" class="RFC">
+....
+
+[#head-element]
+=== &lt;head&gt; Element
+
+The root &lt;html&gt; will contain a &lt;head&gt; element that
+contains the following elements, as needed.
+
+[#charset-declaration]
+==== Charset Declaration
+
+In order to be correctly processed by browsers that load the HTML
+using a mechanism that does not provide a valid content-type
+or charset (such as from a local file system using a "file:" URL),
+the HTML &lt;head&gt; element contains a &lt;meta&gt; element,
+whose &quot;charset&quot; attribute value is "utf-8":
+
+....
+<meta charset="utf-8">
+....
+
+[#head-title]
+==== Document Title
+
+The contents of the &lt;title&gt; element from the XML source
+will be placed inside an HTML &lt;title&gt; element in the
+header.
+
+[#meta]
+==== Document Metadata
+
+The following &lt;meta&gt; elements will be included:
+
+* author - one each for the each of the "fullname"s and "asciiFullname"s of
+all of the &lt;author&gt;s from the &lt;front&gt; of the XML
+source
+* description - the &lt;abstract&gt; from the XML source
+* generator - the name and version number of the software used
+to create the HTML
+* keywords - comma-separated &lt;keyword&gt;s from the XML
+source
+
+For example:
+
+....
+<meta name="author" content="Joe Hildebrand">
+<meta name="author" content="JOE HILDEBRAND">
+<meta name="author" content="Heather Flanagan">
+<meta name="description" content="This document defines...">
+<meta name="generator" content="xmljade v0.2.4">
+<meta name="keywords" content="html,css,rfc">
+....
+
+Note: the HTML &lt;meta&gt; tag does not contain a closing
+slash.
+
+[#xmlsource]
+==== Link to XML Source
+
+The &lt;head&gt; element contains a &lt;link&gt; tag, with "rel"
+attribute of "alternate", "type" attribute of "application/rfc+xml",
+and "href" attribute pointing to the prepared XML source that was
+used to generate this document.
+
+....
+<link rel="alternate" type="application/rfc+xml" href="source.xml">
+....
+
+[#license]
+==== Link to License
+
+The &lt;head&gt; element contains a &lt;link&gt; tag, with "rel"
+attribute of "license" and "href" attribute pointing to the an
+appropriate copyright license for the document.
+
+....
+<link rel="license" 
+   href="https://trustee.ietf.org/trust-legal-provisions.html">
+....
+
+[#style]
+==== Style
+
+The &lt;head&gt; element contains an embedded CSS in a
+&lt;style&gt; element.  The styles in the style sheet are to be set
+consistently between documents by the RFC Editor, according to the
+best practices of the day.
+
+To ensure consistent formatting, individual style attributes should
+not be used in the main portion of the document.
+
+Different readers of a specification will desire different
+formatting when reading the HTML versions of RFCs.  To facilitate
+this, the &lt;head&gt; element also includes a &lt;link&gt; to a
+style sheet in the same directory as the HTML file, named
+"rfc-local.css". Any formatting in the linked style sheet will
+override the formatting in the included style sheet. For example:
+
+....
+<style>
+  body {}
+  ...
+</style>
+<link rel="stylesheet" type="text/css" href="rfc-local.css">
+....
+
+[#links]
+==== Links
+
+Each &lt;link&gt; element from the XML source is copied into
+the HTML header.  Note: the HTML &lt;link&gt; element does not
+include a closing slash.
+
+[#page-headers-footers]
+=== Page Headers and Footers
+
+In order to simplify printing by HTML renderers that implement
+<<W3C.WD-css3-page-20130314>>, a hidden HTML
+&lt;table&gt; tag of class "ears" is added at the beginning of the HTML &lt;body&gt;
+tag, containing HTML &lt;thead&gt; and &lt;tfoot&gt; tags, each of
+which contains an HTML &lt;tr&gt; tag, which contains three HTML
+&lt;td&gt; tags with class "left", "center", and "right",
+respectively.
+
+The &lt;thead&gt; corresponds to the top of the page, the
+&lt;tfoot&gt; to the bottom.  The string "[Page]" can be used
+as a placeholder for the page number.  In practice, this must
+always be in the &lt;tfoot&gt;'s right &lt;td&gt;, and no control
+of the formatting of the page number is implied.
+
+....
+<table class="ears">
+  <thead>
+    <tr>
+      <td class="left">Internet-Draft</td>
+      <td class="center">HTML RFC</td>
+      <td class="right">March 2016</td>
+    </tr>
+  </thead>
+  <tfoot>
+    <tr>
+      <td class="left">Hildebrand</td>
+      <td class="center">Expires September 2, 2016</td>
+      <td class="right">[Page]</td>
+    </tr>
+  </tfoot>
+</table>
+....
+
+[#document-information]
+=== Document Information
+
+
+Information about the document as a whole will appear as the first child of the
+HTML &lt;body&gt; element, embedded in an HTML &lt;dl&gt; element
+with id="identifiers".  The defined terms in the definition list
+are "Workgroup:", "Series:", "Status:", "Published:", and "Author:"
+or "Authors:" (as appropriate). For example:
+
+....
+<dl id="identifiers">
+  <dt>Workgroup:</dt>
+    <dd class="workgroup">rfc-interest</dd>
+  <dt>Series:</dt>
+    <dd class="series">Internet-Draft</dd>
+  <dt>Status:</dt>
+    <dd class="status">Informational</dd>
+  <dt>Published:</dt>
+    <dd><time datetime="2014-10-25"
+              class="published">2014-10-25</time></dd>
+  <dt>Authors:</dt>
+    <dd class="authors">
+      <div class="author">
+        <span class="initial">J.</span>
+        <span class="surname">Hildebrand</span>
+        (<span class="organization">Cisco Systems, Inc.</span>)
+        <span class="editor">Ed.</span> 
+      </div>
+      <div class="author">
+        <span class="initial">H.</span>
+        <span class="surname">Flanagan</span>
+        (<span class="organization">RFC Editor</span>)
+      </div>
+    </dd>
+</dl>
+....
+
+[#table-of-contents]
+=== Table of Contents
+
+The table of contents will follow the boilerplate if the XML's &lt;rfc&gt;
+element's &quot;tocInclude&quot; attribute has the value "true".  An HTML &lt;h2&gt;
+heading containing the text "Table of Contents" will be followed by a
+&lt;nav&gt; element that contains a &lt;ul&gt; element for each depth
+of the section hierarchy.  Each section will be represented by a
+&lt;li&gt; element containing links by the section number (from the "pn"
+attribute) and by the name (from the "slugifiedName" attribute of the
+&lt;name&gt; child element).  Each &lt;nav&gt;, &lt;ul&gt;, and
+&lt;li&gt; element will have the class "toc".
+
+For example:
+
+....
+<h2 id="toc">Table of Contents</h2>
+<nav class="toc">
+  <ul class="toc">
+    <li class="toc">
+      <a href="s-1">1</a>. <a href="n-introduction">Introduction</a>
+    </li>
+    <ul class="toc">
+      <li class="toc">
+        <a href="s-1.1">1.1</a>. <a href="n-sub-intro">Sub Intro</a>
+      </li>
+...
+....
+
+[#middle]
+== Main Body
+
+The main body of the HTML document is processed according to the rules in
+<<elements>>.
+
+[#back-matter]
+== Back Matter
+
+
+The back matter of the HTML document includes an index (if generated),
+information about the authors, and further information about the
+document itself.
+
+[#index]
+=== Index
+
+The index will be produced as dictated by the RFC Editor's Style
+	Guide <<RFC-STYLE>> if and only if the XML document's &lt;rfc&gt; 
+element has an &quot;indexInclude&quot; attribute with the value "true" and there
+is one or more &lt;iref&gt; elements in the document.
+
+[#index-index]
+==== Index Contents
+
+The index section will start with an &lt;h2&gt; heading containing
+the text "Index", followed by links to each of the lettered
+portions of the index.  Links are not generated for letters that
+do not occur as the first letter of an index item.
+
+For example:
+
+....
+<h2>Index</h2>
+<div class="index">
+  <div class="indexIndex">
+    <a href="#rfc.index.C">C</a>
+    <a href="#rfc.index.P">P</a>
+  </div>
+  ...
+....
+
+[#index-letters]
+==== Index Letters
+
+The index letter is followed by a &lt;ul&gt; tag that contains an
+&lt;li&gt; tag for each first letter represented in the index. This
+&lt;li&gt; tag has the class "indexChar" and contains an &lt;a&gt;
+tag with the id pointed to by the index letter as well as an
+&quot;href&quot; attribute to itself.  The &lt;li&gt; tag also includes a &lt;ul&gt; tag
+that will contain the index items.
+
+For example:
+
+....
+<ul>
+  <li class="indexChar">
+    <a href="#rfc.index.C" id="rfc.index.C">C</a>
+    <ul>
+      <!-- items go here -->
+    </ul>
+  </li>
+  ...
+....
+
+[#index-items]
+==== Index Items
+
+Each index item can have multiple &lt;iref&gt; elements to point to, all
+with the same item attribute.  Each index item is represented by an
+&lt;li&gt; tag of class "indexItem" containing a &lt;span&gt; of class
+"irefItem" for the item text and one of class "irefRefs" for the generated
+references (if there is at least one reference to the item not having
+a subitem).  Each generated reference contains an &lt;a&gt; tag
+containing the section number where the &lt;iref&gt; is found, with
+an "href" attribute pointing to the "irefid" attribute of the &lt;iref&gt; element from the XML document. If the primary
+attribute of the &lt;iref&gt; element has the value "true", the &lt;a&gt; element in the HTML document
+will have the class "indexPrimary". Commas may be used to separate the
+generated references.
+
+For example:
+
+....
+<li class="indexItem">
+  <span class="irefItem">Bullets</span>
+  <span class="irefRefs">
+    <a class="indexPrimary" href="#s-Bullets-1">2</a>,
+    <a href="#s-Bullets-2">2</a>
+  </span>
+  <!-- subitems go here -->
+</li>
+...
+....
+
+[#index-subitems]
+==== Index Subitems
+
+If an index item has at least one subitem, the &lt;li&gt; of
+that item will contain a &lt;ul&gt;, with one &lt;li&gt; for each
+subitem, of class "indexSubItem".  The format for each subitem is 
+similar to that used for items, except the class of the first &lt;span&gt;
+tag is "irefSubItem".
+
+For example:
+
+....
+<ul>
+  <li class="indexSubItem">
+    <span class="irefSubItem">Ordered</span>
+    <span class="irefRefs">
+      <a href="#s-Bullets-Ordered-1">2</a>
+    </span>
+  </li>
+</ul>
+...
+....
+
+[#authors-addresses]
+=== Authors' Addresses Section
+
+At the end of the document, author information will be included
+inside an HTML &lt;section&gt; element whose &quot;id&quot; attribute is
+"author-addresses".  The class names of the constituent HTML tags
+have been chosen to match the class names in <<HCARD>>.
+
+The information for each author will be separated by an HTML
+&lt;hr&gt; element with class "addr".
+
+....
+<section id="author-addresses">
+  <h2>
+    <a class="selfRef" href="#author-addresses">
+      Authors' Addresses
+    </a>
+  </h2>
+  <address class="vcard">
+    <div class="nameRole"><span class="fn">Joe Hildebrand</span>
+      (<span class="role">editor</span>)</div>
+    <div class="org">Cisco Systems, Inc.</div>
+  </address>
+  <hr class="addr">
+  <address class="vcard">
+    <div class="nameRole"><span class="fn">Heather Flanagan</span>
+      (<span class="role">editor</span>)</div>
+    <div class="org">RFC Series Editor</div>
+  </address>
+</section>
+....
+
+[#docInfo]
+=== Document Information
+
+A few bits of metadata about the document that are less
+important to most readers are included after the author information.
+These are gathered together into a &lt;div&gt; of class
+"docInfo".
+
+
+The finalized time is copied from the &lt;rfc&gt; element's
+&quot;prepTime&quot; attribute.  The rendered time is the time that this
+HTML was generated.
+
+For example:
+
+....
+<div class="docInfo">
+  <span class="finalized">
+    Finalized: <time
+    datetime="2015-04-29T18:59:08Z">2015-04-29T18:59:08Z</time>
+  </span>
+  <span class="rendered">
+    Rendered: <time
+    datetime="2015-04-29T18:59:10Z">2015-04-29T18:59:10Z</time>
+  </span>
+</div>
+....
+
+[#elements]
+== Elements
+
+This section describes how each of the XML elements from
+<<RFC7991>> is rendered to HTML.
+Many of the descriptions have examples to clarify how elements will be rendered.
+
+[#element-abstract]
+=== &lt;abstract&gt;
+
+The abstract is rendered in a similar fashion to a &lt;section&gt; with anchor="abstract" and
+&lt;name&gt;Abstract&lt;/name&gt;, but without a section number.
+
+....
+<section id="abstract">
+  <h2><a href="#abstract" class="selfRef">Abstract</a></h2>
+  <p id="s-abstract-1">This document defines...
+    <a href="#s-abstract-1" class="pilcrow">&para;</a>
+  </p>
+</section>
+....
+
+
+[#element-address]
+=== &lt;address&gt;
+
+This element is used in the Authors' Addresses section.
+It is rendered
+as an HTML &lt;address&gt; tag of class "vcard".  If none of the
+descendant XML elements has an "ascii" attribute, the &lt;address&gt;
+HTML tag includes the HTML rendering of each of the descendant
+XML elements.  Otherwise, the &lt;address&gt; HTML tag includes
+an HTML &lt;div&gt; tag of class "ascii" (containing the HTML
+rendering of the ASCII variants of each of the descendant XML
+elements), an HTML &lt;div&gt; tag of class "alternative-contact",
+(containing the text "Alternate contact information:"), and
+an HTML &lt;div&gt; tag of class "non-ascii" (containing the HTML
+rendering of the non-ASCII variants of each of the descendant XML
+elements).
+
+
+Note: the following example shows some ASCII equivalents that are
+the same as their nominal equivalents for clarity; normally, the ASCII
+equivalents would not be included for these cases.
+
+....
+<address class="vcard">
+  <div class="ascii">
+    <div class="nameRole"><span class="fn">Joe Hildebrand</span>
+      (<span class="role">editor</span>)</div>
+    <div class="org">Cisco Systems, Inc.</div>
+  </div>
+  <div class="alternative-contact">
+    Alternate contact information:
+  </div>
+  <div class="non-ascii">
+    <div class="nameRole"><span class="fn">Joe Hildebrand</span>
+      (<span class="role">editor</span>)</div>
+    <div class="org">Cisco Systems, Inc.</div>
+  </div>
+</address>
+....
+
+[#element-annotation]
+=== &lt;annotation&gt;
+
+This element is rendered as the text ", " (a comma and a space)
+followed by a &lt;span&gt; of class "annotation" at the end
+of a &lt;reference&gt; element, the &lt;span&gt;
+containing appropriately transformed elements from the children of
+the &lt;annotation&gt; tag.
+
+....
+ <span class="annotation">Some <em>thing</em>.</span>
+....
+
+[#element-area]
+=== &lt;area&gt;
+
+Not currently rendered to HTML.
+
+[#element-artwork]
+=== &lt;artwork&gt;
+
+Artwork can consist of either inline text or SVG.  If the artwork is
+not inside a &lt;figure&gt; element, a
+<<pilcrows,pilcrow>> is included.  Inside a
+&lt;figure&gt; element, the figure title serves the purpose of the
+pilcrow. If the "align" attribute has the value "right", the CSS class
+"alignRight" will be added. If the "align" attribute has the value
+"center", the CSS class "alignCenter" will be added.
+
+[#element-artwork-text]
+==== Text Artwork
+
+Text artwork is rendered inside an HTML &lt;pre&gt; element, which
+is contained by a &lt;div&gt; element for consistency with SVG
+artwork.  Note that CDATA blocks are not a part of HTML,
+so angle brackets and ampersands (i.e., &lt;, &gt;, and &amp;) must be escaped as &amp;lt;, &amp;gt;,
+and &amp;amp;, respectively.
+
+The &lt;div&gt; element will have CSS classes of "artwork",
+"art-text", and "art-" prepended to the value of the &lt;artwork&gt;
+element's "type" attribute, if it exists.
+
+....
+<div class="artwork art-text art-ascii-art"  id="s-1-2">
+  <pre>
+ ______________
+&lt; hello, world &gt;
+ --------------
+  \   ^__^
+   \  (oo)\_______
+      (__)\       )\/\
+          ||----w |
+          ||     ||
+  </pre>
+  <a class="pilcrow" href="#s-1-2">&para;</a>
+</div>
+....
+
+[#element-artwork-svg]
+==== SVG Artwork
+
+SVG artwork will be included inline.  The SVG is wrapped in a
+&lt;div&gt; element with CSS classes "artwork" and "art-svg".
+
+If the SVG &quot;artwork&quot; element is a child of &lt;figure&gt; and the
+artwork is specified as align="right", an
+empty HTML &lt;span&gt; element is added directly after the
+&lt;svg&gt; element, in order to get right alignment to work correctly
+in HTML rendering engines that do not support the flex-box
+model.
+
+Note: the &quot;alt&quot; attribute of &lt;artwork&gt; is not currently used
+for SVG; instead, the &lt;title&gt; and &lt;desc&gt; tags are used
+in the SVG.
+
+....
+<div class="artwork art-svg" id="s-2-17">
+  <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <desc>Alt text here</desc>
+    <circle
+      cx="50" cy="50" r="40"
+      stroke="green" stroke-width="4" fill="yellow" />
+  </svg>
+  <a href="#s-2-17" class="pilcrow">&para;</a>
+</div>
+....
+
+[#element]
+==== Other Artwork
+
+Other artwork will have a &quot;src&quot; attribute that uses the "data" URI scheme
+defined in <<RFC2397>>.  Such artwork is rendered in an
+HTML &lt;img&gt; element.  Note: the HTML &lt;img&gt; element does
+not have a closing slash.
+
+Note: such images are not yet allowed in RFCs
+even though the format supports them.  A limited set of "data:" mediatypes for artwork may be allowed in the
+future.
+
+....
+<div class="artwork art-logo" id="s-2-58">
+  <img alt="IETF logo"
+       src="data:image/gif;charset=utf-8;base64,...">
+  <a class="pilcrow" href="#s-2-58">&para;</a>
+</div>
+....
+
+[#element-aside]
+=== &lt;aside&gt;
+
+This element is rendered as an HTML &lt;aside&gt; element, with
+all child content appropriately transformed.
+
+....
+<aside id="s-2.1-2">
+  <p id="s-2.1-2.1">
+    A little more than kin, and less than kind.
+    <a class="pilcrow" href="#s-2.1-2.1">&para;</a>
+  </p>
+</aside>
+....
+
+[#element-author]
+=== &lt;author&gt;
+
+The &lt;author&gt; element is used in several places in the output.
+Different rendering is used for each.
+
+==== Authors in Document Information
+
+As seen in the <<document-information,format=title>>
+at the beginning of the HTML, each document author is rendered
+as an HTML &lt;div&gt; tag of class "author".
+
+
+Inside the &lt;div class="author"&gt; HTML tag, the author's
+initials and surname (or the fullname, if it exists and the others
+do not) will be rendered in an HTML &lt;div&gt;
+tag of class "author-name". If the &lt;author&gt;
+contains "asciiInitials" and "asciiSurname" attributes, or contains
+as "asciiFullname" attribute, the author's name is rendered twice,
+with the first being the non-ASCII version, wrapped in an HTML
+&lt;span&gt; tag of class "non-ascii", followed by the ASCII
+version wrapped in an HTML &lt;span&gt; tag of class "ascii",
+wrapped in parentheses.  If the &lt;author&gt; has a "role"
+attribute of "editor", the &lt;div class="author-name"&gt; will
+also contain the text ", " (comma, space), followed by an HTML
+&lt;span&gt; tag of class "editor", which contains the text "Ed.".
+
+If the &lt;author&gt; element contains an
+<<element-organization,format=title>>
+element, it is also rendered inside the &lt;div class="author"&gt;
+HTML tag. 
+
+....
+<div class="author">
+  <div class="author-name">
+    H. Flanagan,
+    <span class="editor">Ed.</span></div>
+  <div class="org">Test Org</div>
+</div>
+<div class="author">
+  <div class="author-name">
+    <span class="non-ascii">Hildebrand</span>
+    (<span class="ascii">HILDEBRAND</span>)
+  </div>
+  <div class="org">
+    <span class="non-ascii">Test Org</span>
+    (<span class="ascii">TEST ORG</span>)
+  </div>
+</div>
+....
+
+==== Authors of This Document
+
+As seen in the Authors' Addresses section,
+at the end of the HTML, each document author is rendered into an
+HTML &lt;address&gt; element with the CSS class "vcard".
+
+The HTML &lt;address&gt; element will contain an HTML &lt;div&gt;
+with CSS class "nameRole".  That div will contain an HTML &lt;span&gt;
+element with CSS class "fn" containing the value of the "fullname"
+attribute of the &lt;author&gt; XML element and an HTML &lt;span&gt;
+element with CSS class "role" containing the value of the "role"
+attribute of the &lt;author&gt; XML element (if there is a role).
+Parentheses will surround the &lt;span class="role"&gt;, if it
+exists.
+
+....
+<address class="vcard">
+  <div class="nameRole">
+    <span class="fn">Joe Hildebrand</span>
+    (<span class="role">editor</span>)
+  </div>
+  ...
+....
+
+After the name, the
+<<element-organization,format=title>> and
+<<element-address,format=title>> child elements of
+the author are rendered inside the HTML &lt;address&gt; tag.
+
+When the &lt;author&gt; element, or any of its descendant elements,
+has any attribute that starts with "ascii", all of the author
+information is displayed twice.  The first version is wrapped in
+an HTML &lt;div&gt; tag with class "ascii"; this version prefers
+the ASCII version of information, such as "asciiFullname", but falls
+back on the non-ASCII version if the ASCII version doesn't exist.
+The second version is wrapped in an HTML &lt;div&gt; tag with class
+"non-ascii"; this version prefers the non-ASCII version of
+information, such as "fullname", but falls back on the ASCII
+version if the non-ASCII version does not exist.  Between these
+two HTML &lt;div&gt;s, a third &lt;div&gt; is inserted, with class
+"alternative-contact", containing the text "Alternate contact
+information:".
+
+....
+<address class="vcard">
+  <div class="ascii">
+    <div class="nameRole">
+      <span class="fn">The ASCII name</span>
+    </div>
+  </div>
+  <div class="alternative-contact">
+    Alternate contact information:
+  </div>
+  <div class="non-ascii">
+    <div class="nameRole">
+      <span class="fn">The non-ASCII name</span>
+      (<span class="role">editor</span>)
+    </div>
+  </div>
+</address>
+....
+
+==== Authors of References
+
+In the output generated from a reference element, author tags are
+rendered inside an HTML &lt;span&gt; element with CSS class
+"refAuthor".  See Section 4.8.6.2 of <<RFC7322>> for
+	    guidance on how author names are to appear.
+
+....
+<span class="refAuthor">Flanagan, H.</span> and
+<span class="refAuthor">N. Brownlee</span>
+....
+
+[#element-back]
+=== &lt;back&gt;
+
+If there is exactly one
+<<element-references,format=title>> child, render
+that child in a similar way to a <<element-section,format=title>>.
+If there are more than one
+<<element-references,format=title>> children, render
+as a <<element-section,format=title>> whose name is
+"References", containing a <<element-section,format=title>>
+for each <<element-references,format=title>> child.
+
+After any <<element-references,format=title>> sections,
+render each <<element-section,format=title>> child of
+	  <<element-back,format=title>>
+as an appendix.
+
+....
+<section id="n-references">
+  <h2 id="s-2">
+    <a class="selfRef" href="#s-2">2.</a>
+    <a class="selfRef" href="#n-references">References</a>
+  </h2>
+  <section id="n-normative">
+    <h3 id="s-2.1">
+      <a class="selfRef" href="#s-2.1">2.1.</a>
+      <a class="selfRef" href="#n-normative">Normative</a>
+    </h3>
+    <dl class="reference"></dl>
+  </section>
+  <section id="n-informational">
+    <h3 id="s-2.2">
+      <a class="selfRef" href="#s-2.2">2.2.</a>
+      <a class="selfRef" href="#n-informational">Informational</a>
+    </h3>
+    <dl class="reference"></dl>
+  </section>
+</section>
+<section id="n-unimportant">
+  <h2 id="s-A">
+    <a class="selfRef" href="#s-A">Appendix A.</a>
+    <a class="selfRef" href="#n-unimportant">Unimportant</a>
+  </h2>
+</section>
+....
+
+[#element-bcp14]
+=== &lt;bcp14&gt;
+
+This element marks up words like MUST and SHOULD <<BCP14>> with an HTML
+&lt;span&gt; element with the CSS class "bcp14".
+
+....
+You <span class="bcp14">MUST</span> be joking.
+....
+
+
+[#element-blockquote]
+=== &lt;blockquote&gt;
+
+This element renders in a way similar to the HTML &lt;blockquote&gt;
+element.  If there is a "cite" attribute, it is  copied
+to the HTML "cite" attribute.  If there is a "quoteFrom" attribute,
+it is placed inside a &lt;cite&gt; element at the end of the quote,
+with an &lt;a&gt; element surrounding it (if there is a "cite"
+attribute), linking to the cited URL.
+
+If the &lt;blockquote&gt; does not contain another element that gets a
+<<pilcrows,pilcrow>>, a pilcrow is added.
+
+Note that the "&amp;mdash;" at the beginning of the &lt;cite&gt; element
+should be a proper emdash, which is difficult to show in the
+display of the current format.
+
+....
+<blockquote id="s-1.2-1"
+  cite="http://...">
+  <p id="s-1.2-2">Four score and seven years ago our fathers
+    brought forth on this continent, a new nation, conceived
+    in Liberty, and dedicated to the proposition that all men
+    are created equal.
+    <a href="#s-1.2-2" class="pilcrow">&para;</a>
+  </p>
+  <cite>&mdash; <a href="http://...">Abraham Lincoln</a></cite>
+</blockquote>
+....
+
+[#element-boilerplate]
+=== &lt;boilerplate&gt;
+
+The Status of This Memo and the Copyright statement, together
+	commonly referred to as the document boilerplate, appear after the
+	Abstract. The children of the input &lt;boilerplate&gt; element
+are treated in a similar fashion to unnumbered sections.
+
+....
+<section id="status-of-this-memo">
+  <h2 id="s-boilerplate-1">
+    <a href="#status-of-this-memo" class="selfRef">
+      Status of this Memo</a>
+  </h2>
+  <p id="s-boilerplate-1-1">This Internet-Draft is submitted in full
+    conformance with the provisions of BCP 78 and BCP 79.
+    <a href="#s-boilerplate-1-1" class="pilcrow">&para;</a>
+  </p>
+...
+....
+
+[#element-br]
+=== &lt;br&gt;
+
+This element is directly rendered as its HTML counterpart.  Note:
+in HTML, &lt;br&gt; does not have a closing slash.
+
+[#element-city]
+=== &lt;city&gt;
+
+This element is rendered as a &lt;span&gt; element with CSS
+class "locality".
+
+....
+<span class="locality">Guilford</span>
+....
+
+[#element-code]
+=== &lt;code&gt;
+
+This element is rendered as a &lt;span&gt; element with CSS
+class "postal-code".
+
+....
+<span class="postal-code">GU16 7HF<span>
+....
+
+[#element-country]
+=== &lt;country&gt;
+
+This element is rendered as a &lt;div&gt; element with CSS
+class "country-name".
+
+....
+<div class="country-name">England</div>
+....
+
+[#element-cref]
+=== &lt;cref&gt;
+
+This element is rendered as a &lt;span&gt; element with CSS
+class "cref".  Any anchor is copied to the &quot;id&quot; attribute.  If there is
+a source given, it is contained inside the &quot;cref&quot; &lt;span&gt; element with another
+&lt;span&gt; element of class "crefSource".
+
+....
+<span class="cref" id="crefAnchor">Just a brief comment
+about something that we need to remember later.
+<span class="crefSource">--life</span></span>
+....
+
+[#element-date]
+=== &lt;date&gt;
+
+
+
+This element is rendered as the HTML &lt;time&gt; element.  If the
+"year", "month", or "day" attribute is included on the XML element,
+an appropriate "datetime" element will be generated in HTML.
+
+If this date is a child of the document's &lt;front&gt; element, it
+gets the CSS class "published".
+
+If this date is inside a &lt;reference&gt; element, it gets the
+CSS class "refDate".
+
+....
+<time datetime="2014-10" class="published">October 2014</time>
+....
+
+[#element-dd]
+=== &lt;dd&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-displayreference]
+=== &lt;displayreference&gt;
+
+This element does not affect the HTML output, but it is used in the generation of the 
+<<element-reference,format=title>>,
+<<element-referencegroup,format=title>>,
+<<element-relref,format=title>>, and
+<<element-xref,format=title>> elements.
+
+[#element-dl]
+=== &lt;dl&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+If the hanging attribute is "false", add the "dlParallel" class, else
+add the "dlHanging" class.
+
+If the spacing attribute is "compact", add the "dlCompact" class.
+
+[#element-dt]
+=== &lt;dt&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-em]
+=== &lt;em&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-email]
+=== &lt;email&gt;
+
+
+This element is
+rendered as an HTML &lt;div&gt; containing the string "Email:" and
+an HTML &lt;a&gt; element with the "href" attribute set to the
+equivalent "mailto:" URI, a CSS class of "email", and the contents set
+to the email address.  If this is the version of the address with
+ASCII, the "ascii" attribute is preferred to the element text.
+
+....
+<div>
+  <span>Email:</span>
+  <a class="email" href="mailto:joe@example.com">joe@example.com</a>
+</div>
+....
+
+[#element-eref]
+=== &lt;eref&gt;
+
+This element is rendered as an HTML &lt;a&gt; element, with the "href"
+attribute set to the value of the "target" attribute and the CSS
+class of "eref".
+
+....
+<a href="https://..." class="eref">the text</a>
+....
+
+[#element-figure]
+=== &lt;figure&gt;
+
+This element renders as the HTML &lt;figure&gt; element, containing
+the artwork or sourcecode indicated and an HTML &lt;figcaption&gt;
+element.  The &lt;figcaption&gt; element will contain an &lt;a&gt; element
+around the figure number.  It will also
+contain another &lt;a&gt; element with CSS class "selfRef" around the
+figure name, if a name was given.
+
+....
+<figure id="f-1">
+  ...
+  <figcaption>
+    <a href="#f-1">Figure 1.</a>
+    <a href="#n-it-figures" id="n-it-figures" class="selfRef">
+      It figures
+    </a>
+  </figcaption>
+</figure>
+....
+
+[#element-front]
+=== &lt;front&gt;
+
+See <<document-information,"Document Information">> for information on this element.
+
+[#element-iref]
+=== &lt;iref&gt;
+
+This element is rendered as an empty &lt;&gt; tag of class &quot;iref&quot;, with
+an &quot;id&quot; attribute consisting of the &lt;iref&gt; element's &quot;irefid&quot; attribute:
+
+....
+<span class="iref" id="s-Paragraphs-first-1"/>
+....
+
+[#element-keyword]
+=== &lt;keyword&gt;
+
+Each &lt;keyword&gt; element renders its text into the &lt;meta&gt;
+keywords in the document's header, separated by commas.
+
+....
+<meta name="keywords" content="html,css,rfc">
+....
+
+[#element-li]
+=== &lt;li&gt;
+
+This element is rendered as its HTML counterpart.  However, if there
+is no contained element that has a
+<<pilcrows,pilcrow>> attached, a pilcrow
+is added.
+
+....
+<li id="s-2-7">Item <a href="#s-2-7" class="pilcrow">&para;</a></li>
+....
+
+[#element-link]
+=== &lt;link&gt;
+
+This element is rendered as its HTML counterpart, in the HTML
+header.
+
+[#element-middle]
+=== &lt;middle&gt;
+
+This element does not add any direct output to HTML.
+
+[#element-name]
+=== &lt;name&gt;
+
+This element is never rendered directly; it is only rendered when
+considering a parent element, such as
+<<element-figure,format=title>>,
+<<element-references,format=title>>,
+<<element-section,format=title>>, or
+<<element-table,format=title>>.
+
+[#element-note]
+=== &lt;note&gt;
+
+This element is rendered like a 
+<<element-section,format=title>> element, but without
+a section number and with the CSS class of "note".  If the
+"removeInRFC" attribute is set to "yes", the generated &lt;div&gt; element
+will also include the CSS class "rfcEditorRemove".
+
+
+....
+<section id="s-note-1" class="note rfcEditorRemove">
+  <h2>
+    <a href="#n-editorial-note" class="selfRef">Editorial Note</a>
+  </h2>
+  <p id="s-note-1-1">
+    Discussion of this draft takes place...
+    <a href="#s-note-1-1" class="pilcrow">&para;</a>
+  </p>
+</section>
+....
+
+[#element-ol]
+=== &lt;ol&gt;
+
+The output created from an &lt;ol&gt; element depends upon the &quot;style&quot;
+attribute.
+
+If the &quot;spacing&quot; attribute has the value "compact", a CSS class of
+"olCompact" will be added.
+
+The group attribute is not copied; the input XML should have start
+values added by a prep tool for all grouped &lt;ol&gt; elements.
+
+[#ol-percent-styles]
+==== Percent Styles
+
+If the style attribute includes the character "%", the output is
+a &lt;dl&gt; tag with the class "olPercent".  Each contained &lt;li&gt; element
+is emitted as a &lt;dt&gt;/&lt;dd&gt; pair, with the generated
+label in the &lt;dt&gt; and the contents of the &lt;li&gt; in the
+&lt;dd&gt;.
+
+....
+<dl class="olPercent">
+  <dt>Requirement xviii:</dt>
+  <dd>Wheels on a big rig</dd>
+</dl>
+....
+
+[#ol-standard-styles]
+==== Standard Styles
+
+For all other styles, an &lt;ol&gt; tag is emitted, with any
+&quot;style&quot; attribute turned into the equivalent HTML attribute.
+
+....
+<ol class="compact" type="I" start="18">
+  <li>Wheels on a big rig</li>
+</ol>
+....
+
+[#element-organization]
+=== &lt;organization&gt;
+
+This element is
+rendered as an HTML &lt;div&gt; tag with CSS class "org".
+
+If the element contains the "ascii" attribute, the organization name
+is rendered twice: once with the non-ASCII version wrapped in an
+HTML &lt;span&gt; tag of class "non-ascii" and then as the ASCII version
+wrapped in an HTML &lt;span&gt; tag of class "ascii" wrapped in
+parentheses.
+
+....
+<div class="org">
+  <span class="non-ascii">Test Org</span>
+  (<span class="ascii">TEST ORG</span>)
+</div>
+....
+
+[#element-phone]
+=== &lt;phone&gt;
+
+
+This element is
+rendered as an HTML &lt;div&gt; tag containing the string "Phone:"  (wrapped
+in a span), an HTML &lt;a&gt; tag with CSS class "tel" containing the
+phone number (and an href with a corresponding "tel:" URI), and an
+HTML &lt;span&gt; with CSS class "type" containing the string
+"VOICE".
+
+....
+<div>
+  <span>Phone:</span>
+  <a class="tel" href="tel:+1-720-555-1212">+1-720-555-1212</a>
+  <span class="type">VOICE</span>
+</div>
+....
+
+[#element-postal]
+=== &lt;postal&gt;
+
+This element renders as an HTML &lt;div&gt; with CSS class
+"adr", unless it contains one or more &lt;postalLine&gt; child
+elements; in which case, it renders as an HTML &lt;pre&gt; element with CSS
+class "label".
+
+When there is no &lt;postalLine&gt; child, the following child
+elements are rendered into the HTML:
+
+* Each &lt;street&gt; is rendered
+* A &lt;div&gt; that includes:
+** The rendering of all &lt;city&gt; elements
+** A comma and a space: ", "
+** The rendering of all &lt;region&gt; elements
+** Whitespace
+** The rendering of all &lt;code&gt; elements
+* The rendering of all &lt;country&gt; elements
+
+
+....
+<div class="adr">
+  <div class="street-address">1 Main Street</div>
+  <div class="street-address">Suite 1</div>
+  <div>
+    <span class="city">Denver</span>,
+    <span class="region">CO</span>
+    <span class="postal-code">80212</span>
+  </div>
+  <div class="country-name">United States of America</div>
+</div>
+....
+
+[#element-postalLine]
+=== &lt;postalLine&gt;
+
+This element renders as the text contained by the element, followed
+by a newline.  However, the last &lt;postalLine&gt; in a given
+&lt;postal&gt; element should not be followed by a newline.  For example:
+
+....
+<postal>
+  <postalLine>In care of:</postalLine>
+  <postalLine>Computer Sciences Division</postalLine>
+</postal>
+....
+
+Would be rendered as:
+
+....
+<pre class="label">In care of:
+Computer Sciences Division</pre>
+....
+
+[#element-refcontent]
+=== &lt;refcontent&gt;
+
+This element renders as an HTML &lt;span&gt; with CSS class
+"refContent".
+
+
+....
+<span class="refContent">Self-published pamphlet</span>
+....
+
+[#element-reference]
+=== &lt;reference&gt;
+
+If the parent of this element is not a &lt;referencegroup&gt;, this
+element will render as a &lt;dt&gt; &lt;dd&gt; pair with the
+defined term being the reference "anchor" attribute surrounded by
+square brackets and the definition including the correct set of
+bibliographic information as specified by <<RFC7322>>.
+The &lt;dt&gt; element will have an "id" attribute of the reference
+anchor.
+
+....
+<dl class="reference">
+  <dt id="RFC5646">[RFC5646]</dt>
+  <dd>
+    <span class="refAuthor">Phillips, A.</span>
+    <span>and</span>
+    <span class="refAuthor">M. Davis</span>
+    <span class="refTitle">"Tags for Identifying Languages"</span>,
+    ...
+  </dd>
+</dl>
+....
+
+
+
+If the child of a &lt;referencegroup&gt;, this
+element renders as a &lt;div&gt; of class "refInstance" whose
+"id" attribute is the value of the &lt;source&gt; element's "anchor"
+attribute.
+
+....
+<div class="refInstance" id="RFC5730">
+  ...
+</div>
+....
+
+[#element-referencegroup]
+=== &lt;referencegroup&gt;
+
+A &lt;referencegroup&gt; is translated into a &lt;dt&gt; &lt;dd&gt;
+pair, with the defined term being the referencegroup "anchor"
+attribute surrounded by square brackets, and the definition containing
+the translated output of all of the child &lt;reference&gt;
+elements.
+
+....
+<dt id="STD69">[STD69]</dt>
+<dd>
+  <div class="refInstance" id="RFC5730">
+    <span class="refAuthor">Hollenbeck, S.</span>
+    ...
+  </div>
+  <div class="refInstance" id="RFC5731">
+    <span class="refAuthor">Hollenbeck, S.</span>
+    ...
+  </div>
+  ...
+</dd>
+....
+
+[#element-references]
+=== &lt;references&gt;
+
+If there is at exactly one &lt;references&gt; element, a
+section is added to the document, continuing with the next
+section number after the last top-level &lt;section&gt; in
+&lt;middle&gt;.  The &lt;name&gt; element of the &lt;references&gt;
+element is used as the section name.
+
+
+....
+<section id="n-my-references">
+  <h2 id="s-3">
+    <a href="#s-3" class="selfRef">3.</a>
+    <a href="#n-my-references class="selfRef">My References</a>
+  </h2>
+  ...
+</section>
+....
+
+If there is more than one &lt;references&gt; element, an HTML
+&lt;section&gt; element  is created to contain a subsection for
+each of the &lt;references&gt;.  The section number will be the next
+section number after the last top-level &lt;section&gt; in
+&lt;middle&gt;. The name of this section will
+be "References", and its "id" attribute will be "n-references".
+
+....
+<section id="n-references">
+  <h2 id="s-3">
+    <a href="#s-3" class="selfRef">3.</a>
+    <a href="#n-references" class="selfRef">References</a>
+  </h2>
+  <section id="n-informative-references">
+    <h3 id="s-3.1">
+      <a href="#s-3.1" class="selfRef">3.1.</a>
+      <a href="#n-informative-references" class="selfRef">
+        Informative References</a></h3>
+    <dl class="reference">...
+    </dl>
+  </section>
+  ...
+</section>
+....
+
+[#element-region]
+=== &lt;region&gt;
+
+This element is rendered as a &lt;span&gt; tag with CSS
+class "region".
+
+
+....
+<span class="region">Colorado</span>
+....
+
+[#element-relref]
+=== &lt;relref&gt;
+
+
+This element is rendered as an HTML &lt;a&gt; tag with CSS class
+"relref" and "href" attribute of the "derivedLink" attribute of the
+element. Different values of the "displayFormat" attribute cause
+the text inside that HTML &lt;a&gt; tag to change and cause extra
+text to be generated.  Some values of the "displayFormat"
+attribute also cause another HTML &lt;a&gt; tag to be rendered
+with CSS class "xref" and an "href" of "#" and the "target" attribute
+(modified by any applicable &lt;displayreference&gt; XML element)
+and text inside of the "target" attribute
+(modified by any applicable &lt;displayreference&gt; XML element).
+When used, this &lt;a class='xref'&gt; HTML tag is always surrounded
+by square brackets, for example, "[&lt;a class='xref' href='#foo'&gt;foo&lt;/a&gt;]".
+
+[#element-relref-df-of]
+==== displayFormat='of'
+
+The output is an &lt;a class='relref'&gt; HTML tag, with
+contents of "Section " and the value of the "section" attribute.
+This is followed by the word "of" (surrounded by whitespace). This
+is followed by the &lt;a class='xref'&gt; HTML tag (surrounded by
+square brackets).
+
+For example, with an input of:
+
+....
+See <relref section="2.3" target="RFC9999" displayFormat="of"
+derivedLink="http://www.rfc-editor.org/info/rfc9999#s-2.3"/>
+for an overview.
+....
+
+
+The HTML generated will be:
+
+....
+See <a class="relref"
+href="http://www.rfc-editor.org/info/rfc9999#s-2.3">Section
+2.3</a> of [<a class="xref" href="#RFC9999">RFC9999</a>]
+for an overview.
+....
+
+[#element-relref-df-comma]
+==== displayFormat='comma'
+
+The output is an &lt;a class='xref'&gt; HTML tag (wrapped by
+square brackets), followed by a comma (","), followed by
+whitespace, followed by an &lt;a class='relref'&gt; HTML tag, with
+contents of "Section " and the value of the "section"
+attribute.
+
+For example, with an input of:
+
+....
+See <relref section="2.3" target="RFC9999" displayFormat="comma"
+derivedLink="http://www.rfc-editor.org/info/rfc9999#s-2.3"/>,
+for an overview.
+....
+
+
+The HTML generated will be:
+
+....
+See [<a class="xref" href="#RFC9999">RFC9999</a>], <a class="relref"
+href="http://www.rfc-editor.org/info/rfc9999#s-2.3">Section 2.3</a>,
+for an overview.
+....
+
+[#element-relref-df-parens]
+==== displayFormat='parens'
+
+The output is an &lt;a&gt; element with "href" attribute whose value
+is the value of the "target" attribute prepended by "#", and whose
+content is the value of the "target" attribute; the entire element
+is wrapped in square brackets.  This is followed by  whitespace.
+This is followed by an &lt;a&gt; element whose "href" attribute is
+the value of the "derivedLink" attribute and whose content is the
+value of the "derivedRemoteContent" attribute; the entire element is
+wrapped in  parentheses.
+
+For example, if Section 2.3 of RFC 9999 has the title "Protocol
+Overview", for an input of:
+
+....
+See <relref section="2.3" target="RFC9999" displayFormat="parens"
+derivedLink="http://www.rfc-editor.org/info/rfc9999#s-2.3"
+derivedRemoteContent="Section 2.3"/> for an overview.
+....
+
+
+The HTML generated will be:
+
+....
+See [<a class="relref" href="#RFC9999">RFC9999</a>]
+(<a class="relref"
+href="http://www.rfc-editor.org/info/rfc9999#s-2.3">Section
+2.3</a>) for an overview.
+....
+
+[#element-relref-df-bare]
+==== displayFormat='bare'
+
+The output is an &lt;a&gt; element whose "href" attribute is
+the value of the "derivedLink" attribute and whose content is the
+value of the "derivedRemoteContent" attribute.
+
+For this input:
+
+....
+See <relref section="2.3" target="RFC9999" displayFormat="bare"
+derivedLink="http://www.rfc-editor.org/info/rfc9999#s-2.3"
+derivedRemoteContent="Section 2.3"/> and ...
+....
+
+
+The HTML generated will be:
+
+....
+See <a class="relref"
+href="http://www.rfc-editor.org/info/rfc9999#s-2.3">Section
+2.3</a> and ...
+....
+
+
+[#element-rfc]
+=== &lt;rfc&gt;
+
+Various attributes of this element are represented in different parts of the HTML
+document.
+
+[#element-section]
+=== &lt;section&gt;
+
+This element is rendered as an HTML &lt;section&gt; element,
+containing an appropriate level HTML heading element
+(&lt;h2&gt;-&lt;h6&gt;).  That heading element contains an &lt;a&gt;
+element around the part number (pn), if applicable (for instance,
+&lt;abstract&gt; does not get a section number).  Another &lt;a&gt;
+element is included with the section's name.
+
+....
+<section id="intro">
+  <h2 id="s-1">
+    <a href="#s-1" class="selfRef">1.</a>
+    <a href="#intro" class="selfRef">Introduction</a>
+  </h2>
+  <p id="s-1-1">Paragraph <a href="#s-1-1" class="pilcrow">&para;</a>
+  </p>
+</section>
+....
+
+[#element-seriesInfo]
+=== &lt;seriesInfo&gt;
+
+This element is rendered in an HTML &lt;span&gt; element with CSS
+name "seriesInfo".
+
+....
+<span class="seriesInfo">RFC 5646</span>
+....
+
+[#element-sourcecode]
+=== &lt;sourcecode&gt;
+
+This element is rendered in an HTML &lt;pre&gt; element with a CSS class of
+"sourcecode".  Note that CDATA blocks do not work consistently in
+HTML, so all &lt;, &gt;, and &amp; must be escaped as &amp;lt;,
+&amp;gt;, and &amp;amp;, respectively.  If the input XML has a "type"
+attribute, another CSS class of "lang-" and the type is added.
+
+If the sourcecode is not inside a &lt;figure&gt; element, a
+<<pilcrows,pilcrow>> is included.  Inside a
+&lt;figure&gt; element, the figure title serves the purpose of the
+pilcrow.
+
+....
+<pre class="sourcecode lang-c">
+#include &lt;stdio.h&gt;
+int main(void)
+{
+    printf(&quot;hello, world\n&quot;);
+    return 0;
+}
+</pre>
+....
+
+[#element-street]
+=== &lt;street&gt;
+
+This element renders as an HTML &lt;div&gt; element with CSS class
+"street-address".
+
+....
+<div class="street-address">1899 Wynkoop St, Suite 600</div>
+....
+
+[#element-strong]
+=== &lt;strong&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-sub]
+=== &lt;sub&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-sup]
+=== &lt;sup&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-t]
+=== &lt;t&gt;
+
+This element is rendered as an HTML &lt;p&gt; element.  A
+<<pilcrows,pilcrow>> is included.
+
+....
+<p id="s-1-1">A paragraph.
+  <a href="#s-1-1" class="pilcrow">&para;</a></p>
+....
+
+[#element-table]
+=== &lt;table&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-tbody]
+=== &lt;tbody&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-td]
+=== &lt;td&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-tfoot]
+=== &lt;tfoot&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-th]
+=== &lt;th&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-thead]
+=== &lt;thead&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-title]
+=== &lt;title&gt;
+
+The title of the document appears in a &lt;title&gt; element in the
+&lt;head&gt; element, as described in <<head-title>>.
+
+The title also appears in an &lt;h1&gt; element and follows directly
+after the Document Information.  The &lt;h1&gt; element has an &quot;id&quot;
+attribute with value "title".
+
+....
+<h1 id="title">HyperText Markup Language Request For
+    Comments Format</h1>
+....
+
+Inside a reference, the title is rendered as an HTML &lt;span&gt;
+tag with CSS class "refTitle".  The text is surrounded by quotes
+inside the &lt;span&gt;.
+
+....
+<span class="refTitle">"Tags for Identifying Languages"</span>
+....
+
+[#element-tr]
+=== &lt;tr&gt;
+
+This element is directly rendered as its HTML counterpart.
+
+[#element-tt]
+=== &lt;tt&gt;
+
+This element is rendered as an HTML &lt;code&gt; element.
+
+[#element-ul]
+=== &lt;ul&gt;
+
+This element is directly rendered as its HTML counterpart. If the
+"spacing" attribute has the value "compact", a CSS class of "ulCompact"
+will be added. If the "empty" attribute has the value "true", a CSS
+class of "ulEmpty" will be added.
+
+[#element-uri]
+=== &lt;uri&gt;
+
+
+
+This element is
+rendered as an HTML &lt;div&gt; containing the string "URI:" and
+an HTML &lt;a&gt; element with the "href" attribute set to the
+linked URI, CSS class of "url" (note that the value is "url", not "uri" as one might expect), and the contents
+set to the linked URI.
+
+
+....
+<div>URI:
+  <a href="http://www.example.com"
+     class="url">http://www.example.com</a>
+</div>
+....
+
+[#element-workgroup]
+=== &lt;workgroup&gt;
+
+This element does not add any direct output to HTML.
+
+[#element-xref]
+=== &lt;xref&gt;
+
+This element is rendered as an HTML &lt;a&gt; element containing an
+appropriate local link as the "href" attribute.  The value of the
+"href" attribute is taken from the "target" attribute,
+prepended by "#".  The &lt;a&gt; element generated will have
+class "xref".  The contents of the &lt;a&gt; element are
+the value of the "derivedContent" attribute. If the "format"
+attribute has the value "default", and the "target" attribute points
+to a &lt;reference&gt; or &lt;referencegroup&gt; element, then
+the generated &lt;a&gt; element is surrounded by square brackets
+in the output.
+
+....
+<a class="xref" href="#target">Table 2</a>
+....
+
+or
+
+....
+[<a class="xref" href="#RFC1234">RFC1234</a>]
+....
+
+[#element-svg]
+=== &lt;svg xmlns='http://www.w3.org/2000/svg'&gt;
+
+This element is rendered as part of the &lt;artwork&gt; element.
+The "xmlns='http://www.w3.org/2000/svg'" namespace declaration should
+be included, and the SVG should be serialized as well-formed XML,
+even for tags that would otherwise not need closing in HTML5.
+
+[#security-considerations]
+== Security Considerations
+
+Since RFCs are sometimes exchanged outside the normal Web sandboxing mechanism
+(such as using the "rsync" program to a mirror site) then loaded from a local file, more care must be taken
+with the HTML than is ordinary on the web. 
+
+[bibliography]
+== Normative References
+
+* [[[BCP14,BCP 14]]]
+* [[[RFC2397,RFC 2397]]]
+* [[[RFC3629,RFC 3629]]]
+* [[[RFC5646,RFC 5646]]]
+* [[[RFC7322,RFC 7322]]]
+* [[[RFC7993,RFC 7993]]]
+* [[[RFC7991,RFC 7991]]]
+* [[[W3C.REC-html5-20141028]]] Hickson, I., Berjon, R., Faulkner, S., Leithead, T., Navara, E., O'Connor, T., and S. Pfeiffer, "HTML5", World Wide Web Consortium Recommendation REC-html5-20141028, October 2014, http://www.w3.org/TR/2014/REC-html5-20141028.
+* [[[W3C.REC-CSS2-20110607]]] Bos, B., Celik, T., Hickson, I., and H. Lie, "Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification", World Wide Web Consortium Recommendation REC-CSS2-20110607, June 2011, http://www.w3.org/TR/2011/REC-CSS2-20110607.
+
+[bibliography]
+== Informative References
+
+* [[[RFC-STYLE]]] RFC Editor, "Style Guide", https://www.rfc-editor.org/styleguide/.
+* [[[W3C.WD-css3-page-20130314]]] Grant, M., Etemad, E., Lie, H., and S. Sapin, "CSS Paged Media Module Level 3", World Wide Web Consortium WD WD-css3-page-20130314, March 2013, http://www.w3.org/TR/2013/WD-css3-page-20130314.
+* [[[HCARD]]] Celik, T., "hCard 1.0", http://microformats.org/wiki/hcard, 2015.
+* [[[RFC6949,RFC 6949]]]
+* [[[RFC7998,RFC 7998]]]
+* [[[RFC7990,RFC 7990]]]
+
+
+:sectnums!:
+== IAB Members at the Time of Approval
+
+The IAB members at the time this memo was approved were (in alphabetical order):                                                       
+
+[spacing=compact]
+* Jari Arkko
+
+* Ralph Droms
+
+* Ted Hardie
+
+* Joe Hildebrand
+
+* Russ Housley
+
+* Lee Howard
+
+* Erik Nordmark
+
+* Robert Sparks
+
+* Andrew Sullivan
+
+* Dave Thaler
+
+* Martin Thomson
+
+* Brian Trammell
+
+* Suzanne Woolf
+
+[#appendix-a-acknowledgments]
+== Acknowledgments
+
+Heather Flanangan was an early coauthor of this document and helped its formation.
+The authors gratefully acknowledge the contributions of: Patrick Linskey and the
+members of the RFC Format Design Team (Nevil Brownlee (ISE), Tony Hansen,
+Ted Lemon, Julian Reschke, Adam Roach, Alice Russo, Robert Sparks
+	(Tools Team liaison), and
+Dave Thaler).
+

--- a/sources/draft-iab-html-rfc-bis/document.adoc
+++ b/sources/draft-iab-html-rfc-bis/document.adoc
@@ -14,6 +14,7 @@ Joe Hildebrand <joe-ietf@cursive.net>; Paul Hoffman <paul.hoffman@icann.org>
 :name: 7992
 :docnumber: 7992
 :status: informational
+:intended-series: informational
 :abbrev: HTML for RFCs
 :fullname: Joe Hildebrand
 :surname: Hildebrand

--- a/sources/draft-iab-rfc-framework-bis/document.adoc
+++ b/sources/draft-iab-rfc-framework-bis/document.adoc
@@ -3,6 +3,7 @@ Heather Flanagan <rse@rfc-editor.org>
 :doctype: internet-draft
 :name: draft-iab-rfc-framework-06
 :status: informational
+:intended-series: informational
 :ipr: trust200902
 :toc-include: true
 :abbrev: RFC Format Framework

--- a/sources/draft-iab-rfc-framework-bis/document.adoc
+++ b/sources/draft-iab-rfc-framework-bis/document.adoc
@@ -1,0 +1,308 @@
+= RFC Format Framework
+Heather Flanagan <rse@rfc-editor.org>
+:doctype: internet-draft
+:name: draft-iab-rfc-framework-06
+:status: informational
+:ipr: trust200902
+:toc-include: true
+:abbrev: RFC Format Framework
+:fullname: Heather Flanagan
+:surname: Flanagan
+:givenname: Heather
+:initials: H.
+:email: rse@rfc-editor.org
+:organization: RFC Editor
+:uri: http://orcid.org/0000-0002-2647-2220
+:revdate: 2016-06-23
+:area: General
+:workgroup: Internet Architecture Board
+:rfc2629xslt: true
+
+
+The canonical format for the RFC Series has been plain-text, ASCII-encoded for several decades.  After extensive community discussion and debate, the RFC Editor will be transitioning to XML as the canonical format using the XML2RFC version 3 vocabulary. Different publication formats will be rendered from that base document.  These changes are intended to increase the usability of the RFC Series by offering documents that match the needs of a wider variety of stakeholders.  With these changes, however, comes an increase in complexity for authors, consumers, and the publisher of RFCs.  This document serves as the framework that describes the problems being solved and summarizes the many documents that capture the specific requirements for each aspect of the change in format.
+
+[NOTE]
+.Editorial Note (To be removed by RFC Editor)
+Discussion of this draft takes place on the rfc-interest mailing list (\rfc-interest@rfc-editor.org), which has its home page at \https://www.rfc-editor.org/mailman/listinfo/rfc-interest.
+
+[#introduction]
+== Introduction
+"RFC Series Format Requirements and Future Development" discussed the need for additional features within RFCs such as non-ASCII characters to respect author names, more advanced artwork than ASCII art, and documents that could display properly on a wide variety of devices <<RFC6949>>.  Based on the discussions with the IETF community as well as other communities of interest, the RFC Series Editor decided to explore a change to the format of the Series <<XML-ANNOUNCE>>.  This document serves as the framework that describes the problems being solved and summarizes the documents created to-date that capture the specific requirements for each aspect of the change in format.  
+
+Key changes to the publication of RFCs are highlighted, and a transition plan that will take the Series from a plain-text, ASCII-only format to the new formats is described on the rfc-interest mailing list <<RFC-INTEREST>>.
+
+This document is concerned with the production of RFCs, focusing on the published formats. It does not address any changes to the processes each stream uses to develop and review their submissions (specifically, how Internet-Drafts will be developed).  While I-Ds have a similar set of issues and concerns, directly addressing those issues for I-Ds will be discussed within each document stream.
+
+The details described in this document are expected to change based on experience gained in implementing the RFC Production Center's toolset. Revised documents will be published capturing those changes as the toolset is completed. Other implementers must not expect those changes to remain backwards-compatible with the details described this document.
+
+[#problem-statement]
+== Problem Statement
+
+There are nearly three billion people connected to the Internet, and individuals from 45 countries or more regularly attending IETF meetings over the last five years <<ISTATS>>.  The Internet is now global, and while the world has changed from when the first RFCs were published, the Series remains critical to defining protocols, standards, best practices, and more for this global network that continues to grow.  In order to make RFCs easily viewable to the largest number of people possible, across a wide array of devices, and to respect the diversity of authors and reference materials while still recognizing the archival aspects of the Series, it is time to update the tightly prescribed format of the RFC Series.
+
+All changes to the format of the RFC Series must consider the requirements of a wide set of communities, over an extended length of time.  For example, existing authors and implementers, lawyers that argue Intellectual Property Rights (IPR), educators, managers, and policy-makers that need to know what to list in potential RFPs for their organizations, all have preferences and requirements for their specific needs.  The immediate needs of today's communities must be balanced with the needs for long-term archival storage.  
+
+[#terminology]
+== Terminology
+
+The following terminology is used as described in RFC 6949:
+
+[empty]
+* ASCII: Coded Character Set - 7-bit American Standard Code for Information Interchange, ANSI X3.4-1986
+
+[empty]
+* Canonical format: the authorized, recognized, accepted, and archived version of the document
+
+[empty]
+* Metadata: information associated with a document so as to provide, for example, definitions of its structure, or of elements within the document such as its topic or author
+
+[empty]
+* Publication format: display and distribution format as it may be read or printed after the publication process has completed
+
+[empty]
+* Reflowable text: text that automatically wraps to the next line in a document as the user moves the margins of the text, either by resizing the window or changing the font size
+
+[empty]
+* Revisable format: the format that will provide the information for conversion into a Publication format; it is used or created by the RFC Editor
+
+[empty]
+* Submission format: the format submitted to the RFC Editor for editorial revision and publication
+
+[#overview-of-the-decision-making-process]
+== Overview of the Decision Making Process
+
+Requirements, use cases, concerns, and suggestions were collected from the communities of interest at every stage of the RFC format update project.  Input was received through the rfc-interest mailing list, as well as in several face-to-face sessions at IETF meetings.  Regular conversations were held with the IETF, IRTF, IAB, and IAOC chairs, and the Independent Stream Editor, to discuss high-level stream requirements.  Updates regarding the status of the project were provided to the IETF community during the IETF Technical Plenary as well as Format BoFs or IAB sessions at IETF 84, IETF 85, IETF 88, IETF 89, and IETF 90 <<IETF84>> <<IETF85>> <<IETF88>> <<IETF89>> <<IETF90>>.
+
+The first document published, RFC 6949, provided the first solid documentation on what the requirements were for the Series and in effect was the output from the first year of discussion on the topic of RFC format.  That RFC, as with all of the RFCs that informed the format update work, was published as an IAB stream document, thus following the process described in RFC 4845, "Process for Publication of IAB RFCs" <<RFC4845>>.  
+
+After the high-level requirements were published, the RFC Series Editor (RSE) brought together an RFC Format Design Team to start working out the necessary details to develop the code needed to create new and changed formats. The design team discussed moving away from the existing xml2rfc vocabulary, but with such a strong existing support base within the community and no clear value with other XML vocabularies or schemas, the decision was made to work with the XML2RFC version 2 (xml2rfc v2)  model and use it as the base for the new format world <<RFC7749>>. Part of this discussion included a decision to stop using an XML document type definition (DTD) in favor of a Regular Language for XML Next General (Relax NG) model using a defined vocabulary. While the bi-weekly calls for this team were limited to Design Team members, review of the decisions as documented in the drafts produced by this team were done publicly through requests for feedback on the rfc-interest mailing list.  Several of the drafts produced by the Design Team, including the xml2rfc v2 and v3 drafts and the SVG profile drafts, were sent through an early GenART review before starting the process to be accepted as an IAB stream draft <<GEN-ART>> <<I-D.iab-xml2rfc>>. 
+
+While the IETF community provided the majority of input on the process, additional outreach opportunities were sought to gain input from an even broader audience.  Informal discussions were held with participants at several International Association of Scientific, Technical, and Medical Publisher events, and presentations made at technical conferences such as the TERENA Networking Conference 2014 and NORDUnet 2014 <<TNC2014>> <<NDN2014>>.
+
+In order to respond to concerns regarding responses to subpoenas and to understand the requirements for lawyers, advice was requested from the IETF Trust legal team regarding what format or formats would be considered reasonable when responding to a subpoena request for an RFC.
+
+Given that several other standards development organizations (SDOs) do not offer plain-text documents, and in fact may offer more than one format for their standards, informal input was sought from them regarding their experience with supporting one or more non-plain-text formats for their standards.
+
+Finally, the entire process was reviewed regularly with the RFC Series Oversight Committee and regular updates provided to the IAB and IESG <<RSOC>>. They have offered support and input throughout the process.
+
+Where consensus was not reached during the process, the RSE made any necessary final decisions, as per the guidance in RFC 6635, "RFC Editor Model (Version 2)" <<RFC6635>>.
+
+[#key-changes]
+== Key Changes
+
+At the highest level, the changes being made to the RFC Format involve breaking away from a pure-ASCII plain text and moving to canonical format that includes all the information required for rendering a document into a wide variety of publication formats.  The RFC Editor will become responsible for more than just the plain-text file and the PDF-from-text format created at time of publication; they will be creating several different formats in order to meet the diverse requirements of the community.
+
+The final XML file produced by the RFC Editor will be considered the canonical format for RFCs; it is the lowest common denominator that holds all the information intended for an RFC.  PDF/A-3 will be the publication format offered in response to subpoenas for RFCs published through this new process, and will be developed with an eye towards long-term archival storage.  HTML will be the focus of providing the most flexible set of features for an RFC, including JavaScript to provide pointers to errata and other metadata.  Plain-text will continue to be offered in order to support existing tool chains where practicable and the individuals who prefer to read RFCs in this format.
+
+[#canonical-format-documents]
+== Canonical Format Documents
+
+[#xml]
+=== XML for RFCs
+
+Key points regarding the XML format:
+
+* The canonical format for RFCs is XML using the XML2RFC version 3 (xml2rfc v3) vocabulary.  This file must contain all information necessary to render a variety of formats; any question about what was intended in the publication will be answered from this format.
+* Authors may submit drafts in xml2rfc v2 vocabulary, but the final publication will convert that to xml2rfc v3 vocabulary.
+* SVG is supported and will be embedded in the final XML file.
+* There will be automatically generated identifiers for sections, paragraphs, figures, and tables in the final XML file.
+* The XML file will not contain any xml2rfc v3 vocabulary elements or attributes that have been marked deprecated. 
+* A Document Type Definition (DTD) will no longer be used. The grammar will be defined using RelaxNG.
+* The final XML file will contain, verbatim, the appropriate boilerplate as applicable at time of publication specified by RFC 5741 or its successors <<RFC5741>>.
+* The final XML will be self-contained with all the information known at publication time. For instance, all features that reference externally-defined input will be expanded. This includes all uses of xinclude, src attributes (such as in <artwork> or <sourcecode> elements), include-like processing instructions, and externally defined entities.
+* The final XML will not contain comments or processing instructions.
+* The final XML will not contain src attributes for <artwork> or 
+<sourcecode> elements.
+
+<<RFC7749>> describes the xml2rfc v2 vocabulary.  While in wide use today, this vocabulary previously had not been formally documented.  In order to understand what needed to change in the vocabulary to allow for a more simple experience and additional features for authors, the current vocabulary needed to be fully described.  This document will be obsoleted by the RFC published from draft-iab-xml2rfc.
+
+<<I-D.iab-xml2rfc>> Describes the xml2rfc v3 vocabulary.  The design goals in this vocabulary were to make the vocabulary more intuitive for authors, and to expand the features to support the changes being made in the publication process.  This draft, when published, will obsolete the RFC 7749.
+
+[#publication-format-documents]
+== Publication Format Documents
+
+[#html]
+=== HTML
+<<I-D.iab-html-rfc>> - Describes the semantic HTML that will be produced by the RFC Editor from the xml2rfc v3 files.
+
+Key points regarding the HTML output:
+
+* The HTML will be rendered from the XML file; it will not be derived from the plain-text publication format.
+* The body of the document will use a subset of HTML. The documents will include CSS for default visual presentation; it can be overwritten by a local CSS file. 
+* SVG is supported and will be included in the HTML file.
+* Text will be reflowable.
+* JavaScript will be supported on a limited basis.  It will not be permitted to overwrite or change any text present in the rendered html.  It may, on a limited basis, add additional text that provides post-publication metadata or pointers if warranted.  All such text will be clearly marked as additional.
+
+[#pdf]
+=== PDF
+<<I-D.iab-rfc-use-of-pdf>> - Describes the tags and profiles that will be used to create the new PDF format, including both the internal structure and the visible layout of the file.  A review of the different versions of PDF is offered, with a recommendation of what PDF standard should apply to RFCs.
+
+Key points regarding the PDF output:
+
+* The PDF file will be rendered from the XML file; it will not be derived from the plain-text publication format.
+* The PDF publication format will conform to the PDF/A-3 standard and will embed the canonical XML source.
+* The PDF will look more like the HTML publication format than the plain-text publication format.
+* The PDF will include a rich set of tags and metadata within the document
+* SVG is supported and will be included in the PDF file.
+
+[#plain-text]
+=== Plain Text
+<<I-D.iab-rfc-plaintext>> - Describes the details of the plain text format, focusing in particular on what is changing from the existing plain-text output.
+
+Key points regarding the plain-text output:
+
+* The plain-text document will no longer be the canonical version of an RFC.
+* The plain-text format will be UTF-8 encoded; non-ASCII characters will be allowed.
+* A Byte Order Mark (BOM) will be added at the start of each file.
+* Widow and orphan control for the plain-text publication format will not have priority for the developers creating the rendering code <<TYPOGRAPHY>>.
+* Authors may choose to have pointers to line art in other publication formats in place of ASCII art in the .txt file.
+* Both a paginated and an unpaginated plain-text file will be created.
+* Running headers and footers will not be used.
+
+[#potential-future-publication-formats]
+=== Potential Future Publication Formats
+
+[#epub]
+==== EPUB
+This format is intended for use by ebook readers and will be available for RFCs after the requirements have been defined.  No draft is currently available.
+
+[#figures-and-artwork]
+== Figures and Artwork
+
+[#svg]
+=== SVG
+<<I-D.iab-svg-rfc>> Describes the profile for SVG line art.  SVG is an XML-based vocabulary for creating line drawings; SVG information will be embedded within the canonical XML at time of publication.
+
+[#content-and-page-layout]
+== Content and Page Layout
+
+[#non-ascii-characters]
+=== Non-ASCII Characters
+There are security and readability implications to moving outside the ASCII range of characters.  <<I-D.iab-rfc-nonascii>> focuses on exactly where and how non-ASCII characters may be used in an RFC, with an eye towards keeping the documents as secure and readable as possible given the information that needs to be expressed.
+
+[#style-guide]
+=== Style Guide
+The RFC Style Guide <<RFC7322>> was revised to remove as much page formatting information as possible, focusing instead on grammar, structure, and content of RFCs.  Some of the changes recommended, however, informed the XML v3 vocabulary.
+
+[#css-requirements]
+=== CSS Requirements
+<<I-D.iab-rfc-css>> describe how the CSS classes mentioned in the HTML format draft, "HyperText Markup Language Request for Comments Format", should be used to create an accessible and responsive design for the HTML format.
+
+[#transition-plan]
+== Transition Plan
+
+[#tooldev-phase]
+=== Statement of Work and RFP for Tool Development
+Existing tools for the creation of RFCs will need to be updated, and new tools created, to implement the updated format.  As the requirements gathering effort, described in the various documents described earlier int this draft, finishes the bulk of the work, the Tools Development Team of the IETF will work with the RSE to develop Statements of Work (SoWs).  Those SoWs will first be reviewed within the Tools Development Team, the Tools Management Committee, and go out for a public comment period.  After public review, the SoWs will be attached to a Request for Proposal (RFP) and posted as per the IASA bid process <<IASA-RFP>>.
+
+Once bids have been received, reviewed, and awarded, coding will begin.
+
+[#testing-phase]
+=== Testing and Transition
+
+During the I-D review and approval process, authors and stream-approving bodies will select drafts to run through the proposed new publication process.  While the final RFCs published during this time will continue as plain-text and immutable once published, the feedback process is necessary to bootstrap initial testing.  These early tests will target finding issues with the proposed xml2rfc v3 vocabulary that result in poorly formed publication formats as well as issues that prevent proper review of submitted drafts.
+
+Feedback will result in regular iteration of the basic code and XML vocabulary.  In order to limit the amount of time the RFC Production Center (RPC) spends on testing and QA, their priority will be to edit and publish documents; therefore, community assistance will be necessary to help move this stage along.  A mailing list and experimental source directory on the RFC Editor website will be created for community members willing to assist in the detailed review of the XML and publication formats.  Editorial checks of the publication formats by the community are out of scope; the focus will be the QA of each available output, checking for inconsistencies across formats.
+
+The purpose of testing phase is to work with the community to identify and fix bugs in the process and the code, before producing canonical, immutable XML, and to collect additional feedback on the usability of the new publication formats.
+
+Any modifications to the draft review process, up to and including AUTH48, will happen with the community and the stream approving bodies as we learn more about the features and outputs of the new publication tools. Defining those processes is out of scope for this document.
+
+Success will be measured by the closure of all bugs which had been identified by the RPC and the Tools Development team as fatal and consensus on the readiness of the XML vocabulary and final XML files for publication.  The actual rendering engine can go through further review and iteration, as the publication formats may be republished as needed.
+
+Authors are not required to submit their approved drafts in an XML format, though they are strongly encouraged to do so; plain-text will also remain an option for the foreseeable future.  However, documents submitted as plain-text cannot include such features as SVG artwork. The RPC will generate an XML file if necessary for basic processing and subsequent rendering into the approved output formats.
+
+A known risk at this point of the transition is the difficulty in quantifying the resources required from the RPC.  This phase will require more work on the part of the RPC to support both old and new publication processes for at least six months.  There is potential for confusion as consumers of RFCs find some documents published at this time with a full set of outputs, while other documents only have plain text.  There may be a delay in publication as new bugs are found that must be fixed before the files can be converted into the canonical format and associated publication formats.
+
+Final success of the transition will be measured by the closure of all bugs which had been identified by the RPC and the Tools Development team as major or critical.  There must also be rough consensus from the community regarding the utility of the new formats.
+
+[#completion]
+=== Completion
+Authors may submit XML (preferred) or plain text.  The XML drafts submitted for publication will be converted to canonical XML format and published with all available publication formats.  All authors will be expected to review the final documents as consistent with the evolving procedures for reviewing drafts.
+
+Success for this phase will be measured by a solid understanding by the RSE and the IAOC of the necessary costs and resources required for long-term support of the new format model.
+
+[#iana-considerations]
+== IANA Considerations
+
+This document has no actions for IANA.
+
+[#security-considerations]
+== Security Considerations
+
+Changing the format for RFCs involves modifying a great number of components to publication.  Understanding those changes and the implications for the entire tool chain is critical so as to avoid unintended bugs that would allow unintended changes to text.  Unintended changes to text could in turn corrupt a standard, practice or critical piece of information about a protocol.
+
+[#acknowledgements]
+== Acknowledgements
+With many thanks to the RFC Format Design Team for their efforts in making this transition successful: Nevil Brownlee (ISE), Tony Hansen, Joe Hildebrand, Paul Hoffman, Ted Lemon, Julian Reschke, Adam Roach, Alice Russo, Robert Sparks (Tools Team liaison), and Dave Thaler.
+
+[#changelog]
+== Appendix - Change log
+To be removed by RFC Editor
+
+[#change06]
+=== draft-iab-rfc-framework-05 to -06
+xml2rfcv2: minor clarifications
+
+[#change05]
+=== draft-iab-rfc-framework-04 to -05
+Introduction: minor clarifications
+
+Updated references
+
+[#change04]
+=== draft-iab-rfc-framework-03 to -04
+Introduction: editorial changes
+
+Clarified that submitted plain text will be converted to XML by the RPC; the XML will be used to render all output formats. 
+
+[#change03]
+=== draft-iab-rfc-framework-02 to -03
+HTML output: clarified expectations around use of JavaScript.
+
+[#change02]
+=== draft-iab-rfc-framework-01 to -02
+Introduction: Removed some unnecessary history.
+
+[#change01]
+=== draft-iab-rfc-framework-00 to -01
+Decision Making Process: noted taht other XML schemas and vocabularies were considered by the design team
+
+XML for RFCs: "boilerplate at time of publication"
+
+HTML: clarified that JavaScript should not impact readability of the document as it looked at time of publication
+
+[bibliography]
+== Normative References
+
+* [[[RFC6949,RFC 6949]]]
+* [[[RFC7749,RFC 7749]]]
+* [[[I-D.iab-xml2rfc,I-D.iab-xml2rfc]]]
+* [[[I-D.iab-svg-rfc,I-D.iab-svg-rfc]]]
+* [[[I-D.iab-html-rfc,I-D.iab-html-rfc]]]
+* [[[I-D.iab-rfc-use-of-pdf,I-D.iab-rfc-use-of-pdf]]]
+* [[[I-D.iab-rfc-plaintext,I-D.iab-rfc-plaintext]]]
+* [[[I-D.iab-rfc-nonascii,I-D.iab-rfc-nonascii]]]
+* [[[I-D.iab-rfc-css,I-D.iab-rfc-css]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC4845,RFC 4845]]]
+* [[[RFC5741,RFC 5741]]]
+* [[[RFC6635,RFC 6635]]]
+* [[[RFC7322,RFC 7322]]]
+* [[[GEN-ART]]] IETF, "General Area Review Team (Gen-ART)", http://www.ietf.org/iesg/directorate/gen-art.html.
+* [[[IASA-RFP]]] IETF Administrative Support Activity, "RFPs and RFIs", http://iaoc.ietf.org/rfps-rfis.html.
+* [[[IETF84]]] "IETF 84 Proceedings: RFC Format (rfcform)", http://www.ietf.org/proceedings/84/rfcform.html.
+* [[[IETF85]]] "IETF 85 Proceedings: RFC Format (rfcform)", http://www.ietf.org/proceedings/85/rfcform.html.
+* [[[IETF88]]] "IETF 88 Proceedings: RFC Format (rfcform)", http://www.ietf.org/proceedings/88/rfcform.html.
+* [[[IETF89]]] "IETF 89 Proceedings: RFC Format (rfcform)", http://www.ietf.org/proceedings/89/rfcform.html.
+* [[[IETF90]]] "IETF 90 Proceedings: RFC Format (rfcform)", http://www.ietf.org/proceedings/90/rfcform.html.
+* [[[ISTATS]]] "Internet Live Stats", http://www.internetlivestats.com/internet-users/.
+* [[[NDN2014]]] "28th NORDUnet Conference 2014", https://events.nordu.net/display/NORDU2014/BoF%27s+and+side+meetings, 2014.
+* [[[RFC-INTEREST]]] RFC Editor, "rfc-interest -- A list for discussion of the RFC series and RFC Editor functions.", https://www.rfc-editor.org/mailman/listinfo/rfc-interest.
+* [[[RSOC]]] IAB, "RFC Editor Program: The RSOC", http://www.iab.org/activities/programs/rfc-editor-program/.
+* [[[TNC2014]]] "IETF Update - 'What's Hot?' - RFC Update", https://tnc2014.terena.org/core/presentation/84.
+* [[[TYPOGRAPHY]]] "Butterick's Practical Typography", http://practicaltypography.com/widow-and-orphan-control.html.
+* [[[XML-ANNOUNCE]]] "Subject: [rfc-i] Direction of the RFC Format Development effort", http://www.rfc-editor.org/pipermail/rfc-interest/2013-May/005584.html.

--- a/sources/draft-ietf-core-block/document.adoc
+++ b/sources/draft-ietf-core-block/document.adoc
@@ -1,0 +1,910 @@
+= Blockwise transfers in CoAP
+Carsten Bormann <cabo@tzi.org>; Zach Shelby <zach@sensinode.com>
+:doctype: internet-draft
+:name: draft-ietf-core-block-05
+:revdate: 2012-01-13
+:ipr: trust200902
+:area: Applications
+:workgroup: CoRE Working Group
+:keyword: Internet-Draft
+:status: standard
+:toc-include: true
+:sort-refs: yes
+:sym-refs: yes
+:fullname: Carsten Bormann
+:surname: Bormann
+:givenname: Carsten
+:initials: C.
+:organization: Universitaet Bremen TZI
+:street: Postfach 330440
+:city: Bremen
+:code: D-28359
+:country: Germany
+:phone: +49-421-218-63921
+:fax: +49-421-218-7000
+:email: cabo@tzi.org
+:fullname_2: Zach Shelby
+:surname_2: Shelby
+:givenname_2: Zach
+:initials_2: Z.
+:organization_2: Sensinode
+:role_2: editor
+:street_2: Kidekuja 2
+:city_2: Vuokatti
+:code_2: 88600
+:country_2: Finland
+:phone_2: +358407796297
+:email_2: zach@sensinode.com
+:inline-definition-lists: true
+:rfc2629xslt: true
+:compact: no
+
+CoAP is a RESTful transfer protocol for constrained nodes and networks.
+Basic CoAP messages work well for the small payloads we expect
+from temperature sensors, light switches, and similar
+building-automation devices.
+Occasionally, however, applications will need to transfer
+larger payloads -- for instance, for firmware updates. With
+HTTP, TCP does the grunt work of slicing large payloads up
+into multiple packets and ensuring that they all arrive and
+are handled in the right order.
+
+CoAP is based on datagram transports such as UDP or DTLS,
+which limits the maximum size of resource representations that
+can be transferred without too much fragmentation.
+Although UDP supports larger payloads through IP
+fragmentation, it is limited to 64 KiB and, more importantly,
+doesn't really work well for constrained applications and
+networks.
+
+Instead of relying on IP fragmentation, this specification
+extends basic CoAP with a pair of "Block" options, for
+transferring multiple blocks of information from a resource
+representation in multiple request-response pairs. In many
+important cases, the Block options enable a server to be truly
+stateless: the server can handle each block transfer
+separately, with no need for a connection setup or other
+server-side memory of previous block transfers.
+
+In summary, the Block options provide a minimal way to
+transfer larger representations in a block-wise fashion.
+
+
+[#problems]
+== Introduction
+
+The CoRE WG is tasked with standardizing an
+Application Protocol for Constrained Networks/Nodes, CoAP.
+This protocol is intended to provide RESTful <<REST>> services not
+unlike HTTP <<RFC2616>>,
+while reducing the complexity of implementation as well as the size of
+packets exchanged in order to make these services useful in a highly
+constrained network of themselves highly constrained nodes.
+
+This objective requires restraint in a number of sometimes conflicting ways:
+
+* reducing implementation complexity in order to minimize code size,
+* reducing message sizes in order to minimize the number of fragments
+  needed for each message (in turn to maximize the probability of
+  delivery of the message), the amount of transmission power needed
+  and the loading of the limited-bandwidth channel,
+* reducing requirements on the environment such as stable storage,
+  good sources of randomness or user interaction capabilities.
+
+CoAP is based on datagram transports such as UDP, which limit the
+maximum size of resource representations that can be transferred
+without creating unreasonable levels of IP fragmentation.  In
+addition, not all resource representations will fit into a single link
+layer packet of a constrained network, which may cause adaptation
+layer fragmentation even if IP layer fragmentation is not required.
+Using fragmentation (either at the adaptation layer or at the IP
+layer) to enable the transport of larger representations is possible
+up to the maximum size of the underlying datagram protocol (such as
+UDP), but the fragmentation/reassembly process loads the lower layers
+with conversation state that is better managed in the application
+layer.
+
+This specification defines a pair of CoAP options to enable 
+_block-wise_ access to resource representations.
+The Block options provide a minimal way to transfer larger
+resource representations in a block-wise fashion.
+The overriding objective is to avoid
+creating conversation state at the server for block-wise GET requests.
+(It is impossible to fully avoid creating conversation state for
+POST/PUT, if the creation/replacement of resources is to be atomic;
+where that property is not needed, there is no need to create server
+conversation state in this case, either.)
+
+
+In summary, this specification adds a pair of Block options to CoAP that
+can be used for block-wise transfers.  Benefits of using these options
+include:
+
+* Transfers larger than can be accommodated in constrained-network
+  link-layer packets can be performed in smaller blocks.
+* No hard-to-manage conversation state is created at the adaptation
+  layer or IP layer for fragmentation.
+* The transfer of each block is acknowledged, enabling retransmission
+  if required.
+* Both sides have a say in the block size that actually will be used.
+* The resulting exchanges are easy to understand using packet
+  analyzer tools and thus quite accessible to debugging.
+* If needed, the Block options can also be used as is to provide random
+  access to power-of-two sized blocks within a resource representation.
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
+"**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this
+document are to be interpreted as described in RFC 2119, BCP 14
+<<RFC2119>> and indicate requirement levels for compliant CoAP
+implementations.
+
+In this document, the term "byte" is used in its now customary sense
+as a synonym for "octet".
+
+Where bit arithmetic is explained, this document uses the notation
+familiar from the programming language C, except that the operator "**"
+stands for exponentiation.
+
+== Block-wise transfers
+
+As discussed in the introduction, there are good reasons to limit the
+size datagrams in constrained networks:
+
+* by the maximum datagram size (~ 64 KiB for UDP)
+* by the desire to avoid IP fragmentation (MTU of 1280 for IPv6)
+* by the desire to avoid adaptation layer fragmentation (60&ndash;80 bytes
+  for 6LoWPAN)
+
+When a resource representation is larger than can be comfortably
+transferred in the payload of a single CoAP datagram, a Block option
+can be used to indicate a block-wise transfer.  As payloads can be
+sent both with requests and with responses, this specification
+provides two separate options for each direction of payload transfer.
+
+In the following, the term "payload" will be used for the actual
+content of a single CoAP message, i.e. a single block being
+transferred, while the term "body" will be used for the entire
+resource representation that is being transferred in a block-wise
+fashion.
+
+In most cases, all blocks being transferred for a body will be of the
+same size.  The block size is not fixed by the protocol.  To keep the
+implementation as simple as possible, the Block options support only a
+small range of power-of-two block sizes, from 2\\**4 (16) to 2**10
+(1024) bytes.  As bodies often will not evenly divide into the
+power-of-two block size chosen, the size need not be reached in the
+final block; still this size will be given as the block size even for
+the final block.
+
+[#block-option]
+=== The Block Options 
+
+[#block-option-numbers]
+.Block Option Numbers
+[cols=">,<,<,<,<,<",grid=cols]
+|===
+|Type | C/E      | Name   | Format | Length | Default       
+
+|   19 | Critical | Block1 | uint   | 1-3 B  | 0 (see below) 
+|   17 | Critical | Block2 | uint   | 1-3 B  | 0 (see below) 
+|===
+
+Both Block1 and Block2 options can be present both in request and
+response messages.  In either case, the Block1 Option pertains to the
+request payload, and the Block2 Option pertains to the response payload.
+
+Hence, for the methods defined in <<I-D.ietf-core-coap>>, Block1 is
+useful with the payload-bearing POST and PUT requests and their
+responses.  Block2 is useful with GET, POST, and PUT requests and
+their payload-bearing responses (2.01, 2.02, 2.04, 2.05 -- see
+section "Payload" of <<I-D.ietf-core-coap>>).
+
+(As a memory aid: Block_1_ pertains to the payload of the _1st_ part
+of the request-response exchange, i.e. the request, and Block_2_
+pertains to the payload of the _2nd_ part of the request-response
+exchange, i.e. the response.)
+
+Where Block1 is present in a request or Block2 in a response (i.e., in
+that message to the payload of which it pertains) it indicates a
+block-wise transfer and describes how this block-wise payload forms
+part of the entire body being transferred ("descriptive usage").
+Where it is present in the opposite direction, it provides additional
+control on how that payload will be formed or was processed ("control usage").
+
+Implementation of either Block option is intended to be optional.
+However, when it is present in a CoAP message, it **MUST** be processed
+(or the message rejected);
+therefore it is identified as a critical option.
+
+Three items of information may need to be transferred in a Block
+option:
+
+* The size of the block (SZX);
+* whether more blocks are following (M);
+* the relative number of the block (NUM) within a sequence of blocks
+  with the given size.
+
+The value of the option is a 1-, 2- or 3-byte integer which encodes
+these three fields, see <<block>>.
+
+[#block]
+.Block option value
+====
+....
+        0
+        0 1 2 3 4 5 6 7
+       +-+-+-+-+-+-+-+-+
+       |  NUM  |M| SZX |
+       +-+-+-+-+-+-+-+-+
+
+        0                   1
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |          NUM          |M| SZX |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+        0                   1                   2
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   NUM                 |M| SZX |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+....
+====
+
+The block size is encoded as a three-bit unsigned integer (0 for 2\\**4 to 6
+for 2**10 bytes), which we call the `SZX` (size exponent); the
+actual block size is then `2**(SZX + 4)`.  SZX is transferred in the
+three least significant bits of the option value (i.e., `val & 7`
+where `val` is the value of the option).
+
+The fourth least significant bit, the M or "more" bit (`val & 8`),
+indicates whether more blocks are following or the current block-wise
+transfer is the last block being transferred.
+
+The option value divided by sixteen (the NUM field) is the sequence
+number of the block currently being transferred, starting from
+zero. The current transfer is therefore about the `size` bytes
+starting at byte `NUM << (SZX + 4)`.  (Note that, as an implementation
+convenience, `(val & ~0xF) << (val & 7)`, i.e. the option value with
+the last 4 bits masked out, shifted to the left by the value of SZX,
+gives the byte position of the block.)
+
+The default value of both the Block1 and the Block2 Option is zero,
+indicating that the current block is the first and only block of the
+transfer (block number 0, M bit not set); however, there is no
+explicit size implied by this default value.
+
+More specifically, within the option value of a Block1 or Block2
+Option, the meaning of the option fields is defined as follows:
+
+NUM: :: Block Number. The block number is a variable-size (4, 12, or 20 bit)
+  unsigned integer (uint, see Appendix A of <<I-D.ietf-core-coap>>)
+  indicating the block number being requested or provided. Block
+  number 0 indicates the first block of a body.
+
+M: :: More Flag (not last block). For descriptive usage, this flag, if
+  unset, indicates that the payload in this message is the last block
+  in the body; when set it indicates that there are one or more
+  additional blocks available.  When a Block2 Option is used in a
+  request to retrieve a specific block number ("control usage"), the M
+  bit **MUST** be sent as zero and ignored on reception.  (In a Block1
+  Option in a response, the M flag is used to indicate atomicity, see
+  below.)
+
+SZX: :: Block Size. The block size is a three-bit unsigned integer indicating the size of a block to
+  the power of two. Thus block size = 2&#42;&#42;(SZX + 4).  The allowed
+  values of SZX are 0 to 6, i.e., the minimum block size is 2&#42;&#42;(0+4) = 16
+  and the maximum is 2&#42;&#42;(6+4) = 1024.
+  The value 7 for SZX (which would indicate a block size of 2048) is
+  reserved, i.e. [bcp14]#MUST NOT# be sent and [bcp14]#MUST# lead to a 4.00 Bad Request
+  response code upon reception in a request.
+
+The Block options are used in one of three roles:
+
+* In descriptive usage, i.e. a Block2 Option in a response (e.g., a
+  2.05 response for GET), or a Block1 Option in a request (e.g., PUT
+  or POST):
+** The NUM field in the option value describes what block number is
+    contained in the payload of this message.
+** The M bit indicates whether further
+    blocks are required to complete the transfer of that body.
+** The block size given by SZX **MUST** match the size of the payload in
+    bytes, if the M bit is set. (The block size given is irrelevant if
+    M is unset).  For Block2, if the request suggested a larger value
+    of SZX, the next request **MUST** move SZX down to the size given
+    here.  (The effect is that, if the server uses the smaller of its
+    preferred block size and the one requested, all blocks for a body
+    use the same block size.)
+
+* A Block2 Option in control usage in a request (e.g., GET):
+** The NUM field in the Block2 Option gives the block number of the
+    payload that is being requested to be returned in the response.
+** In this case, the M bit has no function and **MUST** be set to zero.
+** The block size given (SZX) suggests a block size (in the case of
+    block number 0) or repeats the block size of previous blocks
+    received (in the case of block numbers other than 0).
+
+* A Block1 Option in control usage in a response (e.g., a 2.xx
+  response for a PUT or POST request):
+** The NUM field of the Block1 Option indicates what block number is
+    being acknowledged.
+** If the M bit was set in the request, the server can choose whether
+    to act on each block separately, with no memory, or whether to
+    handle the request for the entire body atomically, or any mix of
+    the two.  If the M bit is also set in the response, it indicates
+    that this response does not carry the final response code to the
+    request, i.e. the server collects further blocks and plans to
+    implement the request atomically (e.g., acts only upon reception
+    of the last block of payload).  Conversely, if the M bit is unset
+    even though it was set in the request, it indicates the block-wise
+    request was enacted now specifically for this block, and the
+    response carries the final response to this request (and to any
+    previous ones with the M bit set in the response's Block1 Option
+    in this sequence of block-wise transfers); the client is still
+    expected to continue sending further blocks, the request method
+    for which may or may not also be enacted per-block.
+** Finally, the SZX block size given in a control Block1 Option
+    indicates the largest block size preferred by the server for
+    transfers toward the resource that is the same or smaller than the
+    one used in the initial exchange; the client **SHOULD** use this block
+    size or a smaller one in all further requests in the transfer
+    sequence, even if that means changing the block size (and possibly
+    scaling the block number accordingly) from now on.
+
+[#block-usage]
+=== Using the Block Options
+
+Using one or both Block options, a single REST operation can be split
+into multiple CoAP message exchanges.  As specified in
+<<I-D.ietf-core-coap>>, each of these message exchanges uses their own
+CoAP Message ID.
+
+When a request is answered with a response carrying a Block2 Option with
+the M bit set, the requester may retrieve additional blocks of the
+resource representation by sending further
+requests with the same options and a Block2 Option giving the block
+number and block size desired.  In a request, the client **MUST** set the M bit of a Block2 Option
+to zero and the server **MUST** ignore it on reception.
+
+To influence the block size used in a response, the
+requester also uses the Block2 Option, giving the desired size, a block
+number of zero and an M bit of zero.  A server **MUST** use the block
+size indicated or a smaller size.  Any further block-wise requests for
+blocks beyond the first one **MUST** indicate the same block size that was
+used by the server in the
+response for the first request that gave a desired size using a Block2
+Option.
+
+Once the Block2 Option is used by the requester, all requests in a
+single block-wise transfer
+**MUST** ultimately use the same size, except that there may not be enough
+content to fill the last block (the one returned with the M bit not
+set).
+(Note that the client may start using the Block2 Option in a second
+request after a first request without a Block2 Option resulted in a
+Block option in the response.)
+The server **SHOULD** use the block
+size indicated in the request option or a smaller size, but the
+requester **MUST** take note of the actual block size used in the response
+it receives
+to its initial request and proceed to use it in subsequent requests. The
+server behavior **MUST** ensure that this client behavior results in the
+same block size for all responses in a sequence (except for the last
+one with the M bit not set, and possibly the first one if the initial
+request did not contain a Block2 Option).
+
+Block-wise transfers can be used to GET resources the representations
+of which are entirely static (not changing over time at all, such as
+in a schema describing a device), or for dynamically changing
+resources.  In the latter case, the Block2 Option **SHOULD** be used in
+conjunction with the ETag Option, to ensure that the blocks being
+reassembled are from the same version of the representation: The
+server **SHOULD** include an ETag option in each response.  If an ETag
+option is available, the client's reassembler, when reassembling the
+representation from the blocks being exchanged, **MUST** compare ETag
+Options.  If the ETag Options do not match in a GET transfer, the
+requester has the option of attempting to retrieve fresh values for
+the blocks it retrieved first.  To minimize the resulting
+inefficiency, the server **MAY** cache the current value of a
+representation for an ongoing sequence of requests.  The client **MAY**
+facilitate identifying the sequence by using the Token Option with a
+non-default value.  Note well that this specification makes no
+requirement for the server to establish any state; however, servers
+that offer quickly changing resources may thereby make it impossible
+for a client to ever retrieve a consistent set of blocks.
+
+In a request with a request payload (e.g., PUT or POST), the Block1
+Option refers to the payload in the request (descriptive usage).
+
+In response to a request with a payload (e.g., a PUT or POST
+transfer), the block size given in the Block1 Option indicates the
+block size preference of the server for this resource (control usage).
+Obviously, at this point the first block has already been transferred
+by the client without benefit of this knowledge.  Still, the client
+**SHOULD** heed the preference and, for all further blocks, use the block
+size preferred by the server or a smaller one.  Note that any
+reduction in the block size may mean that the second request starts
+with a block number larger than one, as the first request already
+transferred multiple blocks as counted in the smaller size.
+
+To counter the effects of adaptation layer fragmentation on packet
+delivery probability, a client may want to give up retransmitting a
+request with a relatively large payload even before MAX_RETRANSMIT has
+been reached, and try restating the request as a block-wise transfer
+with a smaller payload.  Note that this new attempt is then a new
+message-layer transaction and requires a new Message ID.
+(Because of the uncertainty whether the request or the acknowledgement
+was lost, this strategy is useful mostly for idempotent requests.)
+
+In a blockwise transfer of a request payload (e.g., a PUT or POST) that is intended to be implemented in an
+atomic fashion at the server, the actual creation/replacement takes
+place at the time the final block, i.e. a block with the M bit unset
+in the Block1 Option, is received.  If not
+all previous blocks are available at the server at this time, the
+transfer fails and error code 4.08 (Request Entity Incomplete) **MUST** be returned.  The error
+code 4.13 (Request Entity Too Large) can be returned at any time by a server that does not
+currently have the resources to store blocks for a block-wise request payload transfer that it would intend to implement in an atomic fashion.
+
+If multiple concurrently proceeding block-wise request payload
+transfer (e.g., PUT or POST) operations
+are possible, the requester **SHOULD** use the Token Option to clearly separate the different sequences.
+In this case, when reassembling the representation from the blocks
+being exchanged to enable atomic processing, the reassembler **MUST**
+compare any Token Options present (and, as usual, taking an absent Token Option
+to default to the empty Token).
+If atomic processing is not desired, there is no need to process the
+Token Option (but it is still returned in the response as usual).
+
+== Examples
+
+This section gives a number of short examples with message flows for a
+block-wise GET, and for a PUT or POST.
+These examples demonstrate the basic operation, the operation in the
+presence of retransmissions, and examples for the operation of the
+block size negotiation.
+
+In all these examples, a Block option is shown in a decomposed way
+separating the kind of Block option (1 or 2), block number (NUM), more bit (M), and block size exponent
+(2**(SZX+4)) by slashes.  E.g., a Block2 Option value of 33 would be shown as
+2/2/0/32), or a Block1 Option value of 59 would be shown as 1/3/1/128.
+
+The first example (<<simple-get>>) shows a GET request that is split
+into three blocks.
+The server proposes a block size of 128, and the client agrees.
+The first two ACKs contain 128 bytes of payload each, and third ACK
+contains between 1 and 128 bytes.
+
+[#simple-get]
+.Simple blockwise GET
+====
+....
+CLIENT                                                     SERVER
+  |                                                            |
+  | CON [MID=1234], GET, /status                       ------> |
+  |                                                            |
+  | <------   ACK [MID=1234], 2.05 Content, 2/0/1/128          |
+  |                                                            |
+  | CON [MID=1235], GET, /status, 2/1/0/128            ------> |
+  |                                                            |
+  | <------   ACK [MID=1235], 2.05 Content, 2/1/1/128          |
+  |                                                            |
+  | CON [MID=1236], GET, /status, 2/2/0/128            ------> |
+  |                                                            |
+  | <------   ACK [MID=1236], 2.05 Content, 2/2/0/128          |
+....
+====
+
+In the second example (<<early-get>>), the client anticipates the blockwise transfer
+(e.g., because of a size indication in the link-format description)
+and sends a size proposal.  All ACK messages except for the last carry
+64 bytes of payload; the last one carries between 1 and 64 bytes.
+
+[#early-get]
+.Blockwise GET with early negotiation
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], GET, /status, 2/0/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.05 Content, 2/0/1/64         |
+  |                                                          |
+  | CON [MID=1235], GET, /status, 2/1/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.05 Content, 2/1/1/64         |
+  :                                                          :
+  :                          ...                             :
+  :                                                          :
+  | CON [MID=1238], GET, /status, 2/4/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1238], 2.05 Content, 2/4/1/64         |
+  |                                                          |
+  | CON [MID=1239], GET, /status, 2/5/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1239], 2.05 Content, 2/5/0/64         |
+....
+====
+
+In the third example (<<late-get>>), the client is surprised by the
+need for a blockwise transfer, and unhappy with the size chosen
+unilaterally by the server.  As it did not send a size proposal
+initially, the negotiation only influences the size from the second
+message exchange onward.  Since the client already obtained both the first and
+second 64-byte block in the first 128-byte exchange, it goes on
+requesting the third 64-byte block ("2/0/64").  None of this is (or
+needs to be) understood by the server, which simply responds to the
+requests as it best can.
+
+[#late-get]
+.Blockwise GET with late negotiation
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], GET, /status                     ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.05 Content, 2/0/1/128        |
+  |                                                          |
+  | CON [MID=1235], GET, /status, 2/2/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.05 Content, 2/2/1/64         |
+  |                                                          |
+  | CON [MID=1236], GET, /status, 2/3/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1236], 2.05 Content, 2/3/1/64         |
+  |                                                          |
+  | CON [MID=1237], GET, /status, 2/4/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1237], 2.05 Content, 2/4/1/64         |
+  |                                                          |
+  | CON [MID=1238], GET, /status, 2/5/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1238], 2.05 Content, 2/5/0/64         |
+....
+====
+
+In all these (and the following) cases, retransmissions are handled by
+the CoAP message exchange layer, so they don't influence the block
+operations (<<late-get-lost-con>>, <<late-get-lost-ack>>).
+
+[#late-get-lost-con]
+.Blockwise GET with late negotiation and lost CON
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], GET, /status                     ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.05 Content, 2/0/1/128        |
+  |                                                          |
+  | CON [MID=1235], GE/////////////////////////              |
+  |                                                          |
+  | (timeout)                                                |
+  |                                                          |
+  | CON [MID=1235], GET, /status, 2/2/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.05 Content, 2/2/1/64         |
+  :                                                          :
+  :                          ...                             :
+  :                                                          :
+  | CON [MID=1238], GET, /status, 2/5/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1238], 2.05 Content, 2/5/0/64         |
+....
+====
+
+
+[#late-get-lost-ack]
+.Blockwise GET with late negotiation and lost ACK
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], GET, /status                     ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.05 Content, 2/0/1/128        |
+  |                                                          |
+  | CON [MID=1235], GET, /status, 2/2/0/64           ------> |
+  |                                                          |
+  | //////////////////////////////////tent, 2/2/1/64         |
+  |                                                          |
+  | (timeout)                                                |
+  |                                                          |
+  | CON [MID=1235], GET, /status, 2/2/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.05 Content, 2/2/1/64         |
+  :                                                          :
+  :                          ...                             :
+  :                                                          :
+  | CON [MID=1238], GET, /status, 2/5/0/64           ------> |
+  |                                                          |
+  | <------   ACK [MID=1238], 2.05 Content, 2/5/0/64         |
+....
+====
+
+The following examples demonstrate a PUT exchange; a POST exchange
+looks the same, with different requirements on atomicity/idempotence.
+To ensure that the blocks relate to the same version of the resource
+representation carried in the request, the client in
+<<simple-put-atomic>> sets the Token to
+"v17" in all requests.  Note that, as with the GET, the responses to
+the requests that have a more bit in the request Block2 Option are
+provisional; only the final response tells the client that the PUT
+succeeded.
+
+[#simple-put-atomic]
+.Simple atomic blockwise PUT
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], PUT, /options, v17, 1/0/1/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.04 Changed, 1/0/1/128        |
+  |                                                          |
+  | CON [MID=1235], PUT, /options, v17, 1/1/1/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.04 Changed, 1/1/1/128        |
+  |                                                          |
+  | CON [MID=1236], PUT, /options, v17, 1/2/0/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1236], 2.04 Changed, 1/2/0/128        |
+....
+====
+
+A stateless server that simply builds/updates the resource in place
+(statelessly) may indicate this by not setting the more bit in the
+response (<<simple-put-stateless>>); in this case, the response codes are valid separately for
+each block being updated.  This is of course only an acceptable
+behavior of the server if the potential inconsistency present during
+the run of the message exchange sequence does not lead to problems,
+e.g. because the resource being created or changed is not yet or not currently in
+use.
+
+[#simple-put-stateless]
+.Simple stateless blockwise PUT
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], PUT, /options, v17, 1/0/1/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.04 Changed, 1/0/0/128        |
+  |                                                          |
+  | CON [MID=1235], PUT, /options, v17, 1/1/1/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.04 Changed, 1/1/0/128        |
+  |                                                          |
+  | CON [MID=1236], PUT, /options, v17, 1/2/0/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1236], 2.04 Changed, 1/2/0/128        |
+....
+====
+
+Finally, a server receiving a blockwise PUT or POST may want to indicate a
+smaller block size preference (<<simple-put-atomic-nego>>).
+In this case, the client **SHOULD** continue with a smaller block size; if
+it does, it **MUST** adjust the block number to properly count in that smaller size.
+
+[#simple-put-atomic-nego]
+.Simple atomic blockwise PUT with negotiation
+====
+....
+CLIENT                                                     SERVER
+  |                                                          |
+  | CON [MID=1234], PUT, /options, v17, 1/0/1/128    ------> |
+  |                                                          |
+  | <------   ACK [MID=1234], 2.04 Changed, 1/0/1/32         |
+  |                                                          |
+  | CON [MID=1235], PUT, /options, v17, 1/4/1/32     ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.04 Changed, 1/4/1/32         |
+  |                                                          |
+  | CON [MID=1236], PUT, /options, v17, 1/5/1/32     ------> |
+  |                                                          |
+  | <------   ACK [MID=1235], 2.04 Changed, 1/5/1/32         |
+  |                                                          |
+  | CON [MID=1237], PUT, /options, v17, 1/6/0/32     ------> |
+  |                                                          |
+  | <------   ACK [MID=1236], 2.04 Changed, 1/6/0/32         |
+....
+====
+
+[#http-mapping]
+== HTTP Mapping Considerations 
+
+In this subsection, we give some brief examples for the influence the
+Block options might have on intermediaries that map between CoAP and
+HTTP.
+
+For mapping CoAP requests to HTTP, the intermediary may want to map
+the sequence of block-wise transfers into a single HTTP transfer.
+E.g., for a GET request, the intermediary could perform the HTTP
+request once the first block has been requested and could then fulfill
+all further block requests out of its cache.
+A constrained implementation may not be able to cache the entire
+object and may use a combination of TCP flow control and (in
+particular if timeouts occur) HTTP range requests to obtain the
+information necessary for the next block transfer at the right time.
+
+For PUT or POST requests, there is more variation in how HTTP servers
+might implement ranges.  Some WebDAV servers do, but in general the
+CoAP-to-HTTP intermediary will have to try sending the payload of all
+the blocks of a block-wise transfer within one HTTP request.  If
+enough buffering is available, this request can be started when the
+last CoAP block is received.  A constrained implementation may want to
+relieve its buffering by already starting to send the HTTP request at
+the time the first CoAP block is received; any HTTP 408 status code
+that indicates that the HTTP server became impatient with the
+resulting transfer can then be mapped into a CoAP 4.08 response code
+(similarly, 413 maps to 4.13).
+
+For mapping HTTP to CoAP, the intermediary may want to map a single
+HTTP transfer into a sequence of block-wise transfers.
+If the HTTP client is too slow delivering a request body on a PUT or
+POST, the CoAP server might time out and return a 4.08
+response code, which in turn maps well to an HTTP 408 status code
+(again, 4.13 maps to 413).
+HTTP range requests received on the HTTP side may be served out of a
+cache and/or mapped to GET
+requests that request a sequence of blocks overlapping the range.
+
+(Note that, while the semantics of CoAP 4.08 and HTTP 408 differ, this
+difference is largely due to the different way the two protocols are
+mapped to transport.  HTTP has an underlying TCP connection, which
+supplies connection state, so a HTTP 408 status code can immediately
+be used to indicate that a timeout occurred during transmitting a
+request through that active TCP connection.
+The CoAP 4.08 response code indicates one or more missing blocks,
+which may be due to timeouts or resource constraints; as there is no
+connection state, there is no way to deliver such a response
+immediately; instead, it is delivered on the next block transfer.
+Still, HTTP 408 is probably the best mapping back to HTTP, as the
+timeout is the most likely cause for a CoAP 4.08.
+Note that there is no way to distinguish a timeout from a missing
+block for a server without creating additional state, the need for
+which we want to avoid.)
+
+
+== IANA Considerations
+
+This draft adds the following option numbers to the CoAP Option
+Numbers registry of
+<<I-D.ietf-core-coap>>:
+
+[#tab-option-registry]
+.CoAP Option Numbers
+[cols=">,<,<",grid=cols]
+|===
+| Number | Name   | Reference 
+
+|     17 | Block2 | [RFCXXXX]
+|     19 | Block1 | [RFCXXXX]
+|===
+
+This draft adds the following response code to the CoAP Response Codes registry of
+<<I-D.ietf-core-coap>>:
+
+[#tab-response-code-registry]
+.CoAP Response Codes
+[cols=">,<,<"]
+|===
+| Code | Description                    | Reference 
+
+|  136 | 4.08 Request Entity Incomplete | [RFCXXXX]
+|===
+
+
+== Security Considerations
+
+Providing access to blocks within a resource may lead to
+surprising vulnerabilities.
+Where requests are not implemented atomically, an attacker may be able
+to exploit a race condition or confuse a server by inducing it to use
+a partially updated resource representation.
+Partial transfers may also make certain problematic data invisible to
+intrusion detection systems; it is **RECOMMENDED** that an intrusion
+detection system (IDS) that analyzes resource representations transferred by
+CoAP implement the Block options to gain access to entire resource representations.
+Still, approaches such as transferring even-numbered blocks on one path and odd-numbered
+blocks on another path, or even transferring blocks multiple times
+with different content and
+obtaining a different interpretation of temporal order at the IDS than
+at the server, may prevent an IDS from seeing the whole picture.
+These kinds of attacks are well understood from IP fragmentation and
+TCP segmentation; CoAP does not add fundamentally new considerations.
+
+Where access to a resource is only granted to clients making use of a specific security
+association, all blocks of that resource **MUST** be subject to the same
+security checks; it **MUST NOT** be possible for unprotected exchanges to
+influence blocks of an otherwise protected resource.
+As a related consideration, where object security is employed,
+PUT/POST should be implemented in the atomic fashion, unless the
+object security operation is performed on each access and the
+creation of unusable resources can be tolerated.
+
+[#mitigating-exhaustion-attacks]
+=== Mitigating Resource Exhaustion Attacks
+
+Certain blockwise requests may induce the server to create state, e.g. to
+create a snapshot for the blockwise GET of a fast-changing resource
+to enable consistent access to the same
+version of a resource for all blocks, or to create temporary
+resource representations that are collected until pressed into
+service by a final PUT or POST with the more bit unset.
+All mechanisms that induce a server to create state that cannot simply
+be cleaned up create opportunities for denial-of-service attacks.
+Servers **SHOULD** avoid being subject to resource exhaustion based on state
+created by untrusted sources.
+But even if this is done, the mitigation may cause a denial-of-service
+to a legitimate request when it is drowned out by other state-creating
+requests.
+Wherever possible, servers should therefore minimize the opportunities
+to create state for untrusted sources, e.g. by using stateless approaches.
+
+Performing segmentation at the application layer is almost always
+better in this respect than at the transport layer or lower (IP fragmentation,
+adaptation layer fragmentation), e.g. because there is application
+layer semantics that can be used for mitigation or because lower
+layers provide security associations that can prevent attacks.
+However, it is less common to apply timeouts and keepalive mechanisms
+at the application layer than at lower layers.  Servers **MAY** want to
+clean up accumulated state by timing it out (cf. response code 4.08), and
+clients **SHOULD** be prepared to run blockwise transfers in an expedient
+way to minimize the likelihood of running into such a timeout.
+
+[#mitigating-amplification-attacks]
+=== Mitigating Amplification Attacks
+
+<<I-D.ietf-core-coap>> discusses the susceptibility of
+CoAP end-points for use in amplification attacks.
+
+A CoAP server can reduce the amount of amplification it provides to an
+attacker by offering large resource representations only in relatively
+small blocks.  With this, e.g., for a 1000 byte resource, a 10-byte request might
+result in an 80-byte response (with a 64-byte block) instead of a
+1016-byte response, considerably reducing the amplification provided.
+
+
+== Acknowledgements
+
+Much of the content of this draft is the result of
+discussions with the <<I-D.ietf-core-coap>> authors, and via many CoRE
+WG discussions. Tokens were suggested by Gilman Tolle and refined by
+Klaus Hartke.
+
+Charles Palmer provided extensive editorial comments to a previous
+version of this draft, some of which the authors hope to have covered
+in this version.
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC2616,RFC 2616]]]
+* [[[I-D.ietf-core-coap,I-D.ietf-core-coap]]]
+
+[bibliography]
+== Informative References
+
+* [[[REST]]] Fielding, R., "Architectural Styles and the Design of Network-based Software Architectures", University of California, Irvine, 2000.
+
+
+[#compat]
+== Historical Note
+
+(This appendix to be deleted by the RFC editor.)
+
+An earlier version of this draft used a single option:
+
+[cols=">,<,<,<,<,<"]
+|===
+| Type | C/E      | Name  | Format | Length | Default       
+
+|   13 | Critical | Block | uint   | 1-3 B  | 0 (see below) 
+|===
+
+Note that this option number has since been reallocated in
+<<I-D.ietf-core-coap>>; no backwards compatibility is provided after
+July 1st, 2011.
+

--- a/sources/draft-ietf-core-block/document.adoc
+++ b/sources/draft-ietf-core-block/document.adoc
@@ -8,6 +8,7 @@ Carsten Bormann <cabo@tzi.org>; Zach Shelby <zach@sensinode.com>
 :workgroup: CoRE Working Group
 :keyword: Internet-Draft
 :status: standard
+:intended-series: standard
 :toc-include: true
 :sort-refs: yes
 :sym-refs: yes

--- a/sources/example-v2/document.adoc
+++ b/sources/example-v2/document.adoc
@@ -5,6 +5,7 @@ David Waitzman <dwaitzman@BBN.COM>; Nick Nicholas <opoudjis@gmail.com>
 :obsoletes: RFC 10;RFC 120
 :updates: RFC 2010;RFC 2120
 :status: informational
+:intended-series: informational
 :name: rfc-1149
 :docnumber: 1149
 :ipr: trust200902

--- a/sources/example-v2/document.adoc
+++ b/sources/example-v2/document.adoc
@@ -2,32 +2,37 @@
 David Waitzman <dwaitzman@BBN.COM>; Nick Nicholas <opoudjis@gmail.com>
 :doctype: rfc
 :abbrev: IP Datagrams on Avian Carriers
-:obsoletes: 10, 120
-:updates: 2010, 2120
+:obsoletes: RFC 10;RFC 120
+:updates: RFC 2010;RFC 2120
 :status: informational
 :name: rfc-1149
+:docnumber: 1149
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
 :keyword: this, that
-:revdate: 1990-04-01
-:affiliation: BBN STC
+:revdate: 1990-04-01T00:00:00Z
+:fullname: David Waitzman
+:surname: Waitzman
+:givenname: David
+:email: dwaitzman@BBN.COM
+:organization: BBN STC
 :phone: (617) 873-4323
 :contributor-uri: http://bbn.com
 :street: 10 Moulton Street
 :city: Cambridge
 :code: MA 02238
-:affiliation_2: BBN STC
+:fullname_2: Nick Nicholas
+:surname_2: Nicholas
+:givenname_2: Nick
+:email_2: opoudjis@gmail.com
+:organization_2: BBN STC
 :phone_2: (617) 873-4323
 :street_2: 10 Moulton Street
 :city_2: Cambridge
 :code_2: MA 02238
 :contributor-uri_2: http://opoudjis.net
-:docfile: document.adoc
-:mn-document-class: ietf
-:mn-output-extensions: xml,rfc,txt,html,rxl
 
-[abstract]
 Avian carriers can provide high delay, low throughput, and low
 altitude service.  The connection topology is limited to a single
 point-to-point path for each carrier, used with standard carriers,
@@ -143,46 +148,10 @@ are used in a tactical environment.<<RFC7253>>, <<ISO.IEC.10118-3>>
 
 [bibliography]
 == Normative References
-++++
-<reference anchor='ISO.IEC.10118-3' target='https://www.iso.org/standard/67116.html'>
-  <front>
-    <title>ISO/IEC FDIS 10118-3 -- Information technology -- Security techniques -- Hash-functions -- Part 3: Dedicated hash-functions</title>
-    <author>
-      <organization>International Organization for Standardization</organization>
-      <address>
-        <postal>
-          <street>BIBC II</street>
-          <street>Chemin de Blandonnet 8</street>
-          <street>CP 401</street>
-          <city>Vernier</city>
-          <region>Geneva</region>
-          <code>1214</code>
-          <country>Switzerland</country>
-        </postal>
-        <phone>+41 22 749 01 11</phone>
-        <email>central@iso.org</email>
-        <uri>https://www.iso.org/</uri>
-      </address>
-    </author>
-    <date day='15' month='September' year='2017'/>
-  </front>
-</reference>
-++++
+
+* [[[ISO.IEC.10118-3,ISO/IEC 10118-3]]]
 
 [bibliography]
-== Infomative References
-++++
-<reference anchor='RFC7253' target='https://tools.ietf.org/html/rfc7253'>
-  <front>
-    <title>Guidelines for Writing an IANA Considerations Section in RFCs</title>
-    <author initials="T." surname="Krovetz">
-      <organization>Sacramento State</organization>
-    </author>
-    <author initials="P." surname="Rogaway">
-      <organization>UC Davis</organization>
-    </author>
-    <date month='May' year='2014'/>
-  </front>
-  <seriesInfo name="RFC" value="7253"/>
-</reference>
-++++
+== Informative References
+
+* [[[RFC7253,RFC 7253]]]

--- a/sources/hoffmanv2/document.adoc
+++ b/sources/hoffmanv2/document.adoc
@@ -1,0 +1,216 @@
+= An Example of Using XML for an Internet Draft
+Chris Smith <chrissmith@example.com>; Kim Jones <jk@lmn.op>
+:doctype: internet-draft
+:status: standard
+:name: draft-example-of-xml-00
+:ipr: trust200902
+:consensus: false
+:submission-type: IETF
+:updates: RFC 1234;RFC 5678
+:xml-lang: en
+:abbrev: XML Example
+:fullname: Chris Smith
+:surname: Smith
+:givenname: Chris
+:initials: C.
+:organization: ExampleCorp
+:organization_abbrev: EC
+:street: 123 Exemplar Way
+:city: Anytown
+:region: California
+:code: 95060
+:country: US
+:phone: +1 123-456-7890
+:fax: +1 123-456-7890
+:email: chrissmith@example.com
+:uri: http://www.example.com/corporate/
+:fullname_2: Kim Jones
+:surname_2: Jones
+:givenname_2: Kim
+:initials_2: K.
+:email_2: jk@lmn.op
+:revdate: 2014-09
+:area: General
+:workgroup: Imaginary WG
+:keyword: XML, Imagination
+:inline-definition-lists: true
+:toc-include: false
+:compact: no
+:subcompact: no
+:strict: yes
+:rfc2629xslt: true
+
+This is an example of an abstract.  It is a short paragraph that
+gives an overview of the document in order to help the reader
+determine whether or not they are interested in reading further.
+
+[NOTE]
+.Disclaimer
+This isn't a real RFC, just an example.
+
+[#intro]
+== Introduction
+
+This is the first paragraph of the introduction to this document.
+This introduction is probably much shorter than it would be for a
+real Internet Draft.
+
+Something to note about this paragraph is that it has a pointer to
+<<protocol>>, and one to <<haiku>>, both of which appear later in the
+document. (((Introduction, verbiage)))
+
+=== Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119>>.
+
+[#protocol]
+== The Protocol Being Described
+
+This is a reference to <<RFC6949>>.  Actually, the reference itself is
+not all that interesting, but the way that the reference is
+incorporated is.  Note that the inclusion of RFC 2119 was done at the
+top of the XML, while the information for RFC 6949 is done directly
+in the references section.
+
+The http://www.ietf.org[IETF web site] is _quite_ *nice*, `isn't it`?  Unlike other web sites, it doesn't use
+ +
+ +
+ +
+gratuitous vertical space.
+
+== Basic Lists
+
+Bulleted lists are good for items that are not ordered:
+
+* This is the first item.
+* This is the second item.  Here comes a sub-list:
+**  This is the first sub-item.
+**  This is the second sub-item
++
+and some more detail on the second sub-item.
+
++
+* This is the item after the sub-list.
+
+
+Numbered lists are good for items that are ordered:
+
+.  This is the first item.
+.  This is the second item.  Here comes a sub-list, but with letters:
+[upperalpha]
+.. This is the first sub-item.
+.. This is the second sub-item
+.  This is the item after the sub-list.
+
+And an example of hanging indent.
+
+[hang-indent=15]
+Trees:: These are bigger plants
+Lichen:: These are smaller plants
+
+And the always-interesting "format" for lists.
+
+[format=--%d--]
+.  An element that gets a funny bullet.
+
+==  Figures
+
+The following is a figure with a caption.  Also, it uses the
+ampersand (&) and less than (<) characters in the example text.
+
+[#haiku]
+.This could be haiku
+[type=haiku]
+====
+....
+      The ampersand (&) and
+      less than (<) are two characters
+      that need escaping.
+....
+====
+
+Here are two short figures with no titles and with odd alignment.
+
+[align=center]
+....
+   This might appear in the center.
+....
+
+[align=right]
+....
+This might appear right-aligned.
+....
+
+Here is a figure that is actually pulled from somewhere else.
+[#rememberme]
+[NOTE,source=CS]
+====
+Remember to check whether that file still exists.
+====
+
+[source,src=http://www.example.com/~employees/chrissmith/artwork.txt]
+----
+----
+
+== Tables
+
+The following is a table example.
+
+These are sometimes called "inert" gasses.
+
+.The Noble Gases
+[grid=cols,cols="<25,^50,^25"]
+|===
+| Name    |  Symbol  | Atomic Number 
+
+| Helium  |  He |       2       
+| Neon    |  Ne |       10      
+| Argon   |  Ar |       18      
+| Krypton |  Kr |       36      
+| Xenon   |  Xe |       54      
+| Radon   |  Rn |       86      
+|===
+
+Source: Chemistry 101
+
+The following is a right-aligned table with "full" (but not "all")
+lines between cells.
+
+[align=right,grid=cols]
+[cols="<,>"]
+|===
+| Time      | Mood 
+
+| Morning   | Happy! 
+| Afternoon | Happy! 
+| Evening   | Somber 
+|===
+
+[#IANA]
+==  IANA Considerations
+
+None.
+
+[#Security]
+== Security Considerations
+
+There are no security considerations for an imaginary Internet Draft.
+
+[#Acknowledgements]
+==  Acknowledgements
+
+Some of the things included in this draft came from Elwyn Davies'
+templates.
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC6949,RFC 6949]]]
+* [[[RED]]] Floyd, S. and V. Jacobson, "Random Early Detection (RED) gateways for Congestion Avoidance", IEEE/ACM Transactions on Networking 1(4) 397--413, August 1993, http://www.aciri.org/floyd/papers/early.pdf.

--- a/sources/hoffmanv2/document.adoc
+++ b/sources/hoffmanv2/document.adoc
@@ -2,6 +2,7 @@
 Chris Smith <chrissmith@example.com>; Kim Jones <jk@lmn.op>
 :doctype: internet-draft
 :status: standard
+:intended-series: standard
 :name: draft-example-of-xml-00
 :ipr: trust200902
 :consensus: false

--- a/sources/mib-doc-template/document.adoc
+++ b/sources/mib-doc-template/document.adoc
@@ -2,6 +2,7 @@
 Editor name <Editor email>
 :doctype: internet-draft
 :status: historic
+:intended-series: historic
 :name: Your MIB Document name here rev07
 :ipr: trust200902
 :abbrev: Your MIB Module document name

--- a/sources/mib-doc-template/document.adoc
+++ b/sources/mib-doc-template/document.adoc
@@ -1,0 +1,366 @@
+= Your MIB module document name
+Editor name <Editor email>
+:doctype: internet-draft
+:status: historic
+:name: Your MIB Document name here rev07
+:ipr: trust200902
+:abbrev: Your MIB Module document name
+:fullname: Editor Name
+:surname: Name
+:initials: Y
+:role: editor
+:organization: Editor affiliation
+:street: Editor affiliation address
+:city: Editor affiliation address
+:country: Editor affiliation address
+:phone: Editor address
+:email: Editor email
+:revdate: 2008-01-01
+:area: Operations & Management Area
+:workgroup: Internet Engineering Task Force
+:keyword: Network Management,Management Information Base,MIB,SMIv2
+:smart-quotes: false
+:compact: yes
+:subcompact: no
+:rfcedstyle: yes
+:comments: yes
+:inline: yes
+
+[[CREF1: This template is for authors of IETF specifications containing MIB modules.  This template can be used as a starting point to produce specifications that comply with the Operations & Management Area guidelines for MIB module internet drafts. Throughout the template, the marker "[TEMPLATE TODO]" is used as a placeholder to indicate an element or text that requires replacement or removal. All the places with [TEMPLATE TODO] markers should be replaced or removed before the document is submitted.]]
+
+This memo defines a portion of the Management Information Base (MIB)
+for use with network management protocols. In particular it defines
+objects for managing [TEMPLATE TODO].
+
+[[CREF2: [TEMPLATE TODO]: describe what functionality will be managed using this MIB module. It can be good to mention the protocol being managed, and whether there is a particular aspect of the protocol to be managed, or a particular goal of the module. But keep it brief. Remember, don't put any citations in the abstract, and expand your acronyms. ]]
+
+ 
+[NOTE]
+.Foreword to template users
+====
+This template is intended to help authors write the surrounding text needed in a
+MIB module internet draft, but does not provide a template for writing 
+the MIB module itself.
+
+Throughout this template, the marker "[TEMPLATE TODO]" is used as a reminder
+to the template user to indicate an element or text that requires
+replacement or removal by the template user before submission to the
+internet draft editor. All [TEMPLATE TODO] markers should be resolved and removed
+before you submit your document to the internet-draft editor.
+
+For updated information on MIB module guidelines and templates, see
+<<RFC4181>> and the OPS Area web page and wiki.
+
+For information on writing internet drafts or RFCs, see
+\http://www.ietf.org/ietf/1id-guidelines.txt and 
+RFC2223(bis) <<RFC2223>>, and look
+at \http://www.ietf.org/ID-Checklist.html for issues to note when writing
+drafts.
+
+This template is not meant to be a complete list of everything
+needed to write MIB module internet drafts, but to summarize the often-needed
+basic features to get a document containing a MIB module started. An
+important purpose of the template is to aid authors in developing an
+internet draft that is laid out in a manner consistent with other internet 
+drafts containing MIB modules. Internet drafts submitted for advancement 
+to the standards track typically require review by a MIB Doctor. This 
+template standardizes the layout and naming of sections, includes the 
+appropriate boilerplate text, and facilitates the development of tools 
+to automate the checking of MIB module internet drafts, to speed the WG 
+and IESG review processes.
+
+An XML2RFC template is also available. For information on XML2RFC, see
+RFC2629 <<RFC2629>>, and documentation available at
+\http://xml.resource.org. The XML2RFC version includes
+advice describing how to fill in each section of the template. XML2RFC generates the 
+actual internet-draft from your information, and automatically handles getting up-to-date 
+boilerplates, references, and it handles many idnits issues.
+
+Within the template, there is reference to a SAMPLE-MIB; all references 
+to SAMPLE-MIB should be removed from your internet draft, and should be 
+replaced by references to your MIB module, as appropriate.
+
+[TEMPLATE TODO] THIS section, the complete section entitled "Note: Foreword to
+template users" should be removed by the template user from their
+document before submission.
+
+[TEMPLATE TODO] Remove all page headings from the template document, and
+replace them with the appropriate headings for your internet draft.
+====
+
+[NOTE]
+.Note to RFC Editor re: [TEMPLATE TODO] markers  
+====
+Note to RFC Editor: When a document is developed using this template, the editor of the 
+document should replace or remove all the places marked [TEMPLATE TODO] before submitting the document.
+If there are still [TEMPLATE TODO] markers, please send the document back to the editor.
+====
+
+== Introduction
+This memo defines a portion of the Management Information Base (MIB)
+for use with network management protocols. In particular it defines
+objects for managing the [TEMPLATE TODO].
+
+[[CREF3: [TEMPLATE TODO]: describe what functionality will be managed using this MIB
+module. Include citations for protocol specifications, architectures, related MIB modules, and protocol-specific
+management requirements. Provide an overview of why a MIB module is appropriate for this protocol,  whether there is a 
+particular aspect of the protocol to be managed, and how the module is expected to be used to 
+achieve particular goals. Highlight anything 'different' about the module. For example, 
+a read-only MIB module.]]
+
+== The Internet-Standard Management Framework
+[[CREF4: The title and text for this section has been copied from the 
+official boilerplate, and should not be modified unless the official boilerplate text 
+from the OPS Area web site has changed. See RFC4818 
+section 3.1 for a discussion of the boilerplate section.]]
+
+For a detailed overview of the documents that describe the current
+Internet-Standard Management Framework, please refer to section 7 of RFC
+3410 <<RFC3410>>.
+
+Managed objects are accessed via a virtual information store, termed
+the Management Information Base or MIB. MIB objects are generally
+accessed through the Simple Network Management Protocol (SNMP). Objects
+in the MIB are defined using the mechanisms defined in the Structure of
+Management Information (SMI). This memo specifies a MIB module that is
+compliant to the SMIv2, which is described in STD 58, RFC 2578 <<RFC2578>>, STD 58, RFC 2579 <<RFC2579>> and STD 58, RFC 2580 <<RFC2580>>.
+
+== Conventions
+[[CREF5: [TEMPLATE TODO] This boilerplate should be used if the RFC2119 key words 
+are used in the internet draft. The text in this section has been 
+copied from the official boilerplate, and should not be modified. ]]
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14, RFC 2119 <<RFC2119>>.
+      
+== Overview
+[[CREF6: [TEMPLATE TODO] The narrative part should include an overview section that
+describes the scope and field of application of the MIB modules
+defined by the specification.  See RFC4181 section 3.2 for a
+discussion of the Narrative section.  ]]
+
+== Structure of the MIB Module
+
+[[CREF7: [TEMPLATE TODO] The narrative part SHOULD include one or more sections to
+briefly describe the structure of the MIB modules defined in the
+specification.]]
+
+
+=== Textual Conventions
+[[CREF8: [TEMPLATE TODO] describe the textual conventions defined in the MIB
+module, and their purpose. It may be helpful to highlight any textual conventions
+imported from partner documents. Generic and Common Textual Conventions can be found summarized at 
+the OPS Area web site. If there are no textual conventions used in your MIB module,
+this section should be removed.]]
+
+=== The [TEMPLATE TODO] Subtree
+[[CREF9: [TEMPLATE TODO] copy this section for each subtree in the MIB module, and
+describe the purpose of the subtree. For example, "The fooStats subtree
+provides information for identifying fault conditions and performance
+degradation of the foo functionality."]]
+
+=== The Notifications Subtree
+[[CREF10: [TEMPLATE TODO] describe the notifications defined in the MIB module, and
+their purpose. Include a discussion of congestion control. You might
+want to discuss throttling as well. See RFC2914.]]
+
+=== The Table Structures
+[[CREF11: [TEMPLATE TODO] Describe the tables in the MIB module, their purpose, and their
+reltionship to each other. If the row in one table is related to a row in 
+another table, what happens when one of the rows is deleted? Should the 
+related row be deleted as well? Consider both directions.]]
+
+== Relationship to Other MIB Modules
+[[CREF12: [TEMPLATE TODO]: The narrative part should include a section that specifies the
+relationship (if any) of the MIB modules contained in this internet drafts to
+other standards, particularly to standards containing other MIB
+modules. If the MIB modules defined by the specification import
+definitions from other MIB modules or are always implemented in
+conjunction with other MIB modules, then those facts should be noted in
+the narrataive section, as should any special interpretations of objects
+in other MIB modules. Note that citations may NOT be put into the MIB
+module portions of the internet draft, but documents used for Imported items
+are Normative references, so the citations should exist in the narrative
+section of the internet draft. The preferred 
+way to fill in a REFERENCE clause in a MIB module is of the form: "Guidelines 
+for Writing an IANA Considerations Section in RFCs", RFC2434, section 2.3.]]
+
+=== Relationship to the [TEMPLATE TODO] MIB
+[[CREF13: Example: The Interface MIB [RFC2863] requires that any
+MIB module which is an adjunct of the Interface MIB clarify specific
+areas within the Interface MIB. These areas were intentionally left
+vague in the Interface MIB to avoid over-constraining the MIB, thereby
+precluding management of certain media-types. Section 4 of [RFC2863] enumerates several
+areas which a media-specific MIB must clarify. The implementor is
+referred to [RFC2863] in order to understand the
+general intent of these areas.]]
+
+=== MIB modules required for IMPORTS
+
+[[CREF14: [TEMPLATE TODO]: Citations are not permitted within a MIB module, but any
+module mentioned in an IMPORTS clause or document mentioned in a
+REFERENCE clause is a Normative reference, and must be cited someplace
+within the narrative sections. If there are imported items in the MIB
+module, such as Textual Conventions, that are not already cited, they
+can be cited in text here. Since relationships to other MIB modules
+should be described in the narrative text, this section is typically
+used to cite modules from which Textual Conventions are imported. Example: "The following MIB module IMPORTS objects from SNMPv2-SMI [RFC2578], 
+SNMPv2-TC [RFC2579],
+SNMPv2-CONF [RFC2580], and IF-MIB [RFC2863]."]]
+
+== Definitions
+[[CREF15: This section contains the actual MIB module(s).
+These MIB modules MUST be written in SMIv2 [RFC2578] [RFC2579]
+[RFC2580]. See Section 4 of RFC 4181 for guidelines on SMIv2 usage. 
+See Appendix C of RFC 4181 for suggested naming conventions.]]
+
+....
+[TEMPLATE TODO]: put your valid MIB module here. 
+A list of tools that can help automate the process of 
+checking MIB definitions can be found at the OPS 
+Area web site.
+....
+
+== Security Considerations
+[[CREF16: [TEMPLATE TODO] Each internet draft that defines one or more MIB modules MUST
+contain a section that discusses security considerations relevant to
+those modules. This section MUST be patterned after the latest approved
+template (available at the OPS Area web site).   ]]
+
+
+[[CREF17: [TEMPLATE TODO] if you have any read-write and/or read-create objects, please
+describe their specific sensitivity or vulnerability. RFC 2669 has a very good example.   ]]
+
+There are a number of management objects defined in this MIB module
+with a MAX-ACCESS clause of read-write and/or read-create. Such objects
+may be considered sensitive or vulnerable in some network environments.
+The support for SET operations in a non-secure environment without
+proper protection can have a negative effect on network operations.
+These are the tables and objects and their
+sensitivity/vulnerability:
+
+* {blank}
+
+[[CREF18: [TEMPLATE TODO] else if there are no read-write or read-create objects in your MIB module,
+use the following boilerplate paragraph.]]
+
+There are no management objects defined in this MIB module that have
+a MAX-ACCESS clause of read-write and/or read-create. So, if this MIB
+module is implemented correctly, then there is no risk that an intruder
+can alter or create any management objects of this MIB module via direct
+SNMP SET operations.
+
+[[CREF19: For all MIB modules you must evaluate whether any readable objects
+are sensitive or vulnerable (for instance, if they might reveal customer
+information or violate personal privacy laws such as those of the
+European Union if exposed to unathorized parties).]]
+
+Some of the readable objects in this MIB module (i.e., objects with a
+MAX-ACCESS other than not-accessible) may be considered sensitive or
+vulnerable in some network environments. It is thus important to control
+even GET and/or NOTIFY access to these objects and possibly to even
+encrypt the values of these objects when sending them over the network
+via SNMP. These are the tables and objects and their
+sensitivity/vulnerability: 
+
+* {blank}
+
+* [[CREF20: [TEMPLATE TODO] you should explicitly list by name any readable objects that
+are sensitive or vulnerable and the associated security risks should
+be spelled out.]]
+
+[[CREF21: [TEMPLATE TODO] The following three boilerplate paragraphs
+should not be changed without very good reason. Changes will almost
+certainly require justification during IESG review.]]
+
+SNMP versions prior to SNMPv3 did not include adequate security.
+Even if the network itself is secure (for example by using IPsec),
+there is no control as to who on the secure network is
+allowed to access and GET/SET (read/change/create/delete) the objects
+in this MIB module.
+
+Implementations SHOULD provide the security features described by the   
+SNMPv3 framework (see [RFC3410]), and implementations claiming compliance 
+to the SNMPv3 standard MUST include full support for authentication and 
+privacy via the User-based Security Model (USM) [RFC3414] with the AES 
+cipher algorithm [RFC3826]. Implementations MAY also provide support for
+the Transport Security Model (TSM) [RFC5591] in combination with a secure 
+transport such as SSH [RFC5592] or TLS/DTLS [RFC6353]. 
+
+Further, deployment of SNMP versions prior to SNMPv3 is NOT
+RECOMMENDED. Instead, it is RECOMMENDED to deploy SNMPv3 and to enable
+cryptographic security. It is then a customer/operator responsibility to
+ensure that the SNMP entity giving access to an instance of this MIB
+module is properly configured to give access to the objects only to
+those principals (users) that have legitimate rights to indeed GET or
+SET (change/create/delete) them.
+
+== IANA Considerations
+[[CREF22: [TEMPLATE TODO] In order to comply with IESG policy as set forth in
+\http://www.ietf.org/ID-Checklist.html, every Internet-Draft that is
+submitted to the IESG for publication MUST contain an IANA
+Considerations section. The requirements for this section vary depending
+what actions are required of the IANA. See "Guidelines for Writing an IANA 
+Considerations Section in RFCs" [RFC2434]. and see RFC4181 section 3.5 for more
+information on writing an IANA clause for a MIB module internet draft.]]
+
+Option #1:
+
+....
+     The MIB module in this document uses the following IANA-assigned
+     OBJECT IDENTIFIER values recorded in the SMI Numbers registry: 
+      
+     Descriptor        OBJECT IDENTIFIER value
+     ----------        -----------------------
+     sampleMIB         { mib-2 XXX }
+....
+
+Option #2:
+
+Editor's Note (to be removed prior to publication): the IANA is
+requested to assign a value for "XXX" under the 'mib-2' subtree and to
+record the assignment in the SMI Numbers registry. When the assignment
+has been made, the RFC Editor is asked to replace "XXX" (here and in the
+MIB module) with the assigned value and to remove this note.
+
+Note well: prior to official assignment by the IANA, an internet
+draft MUST use placeholders (such as "XXX" above) rather than actual
+numbers. See RFC4181 Section 4.5 for an example of how this is done in
+an internet draft MIB module.
+
+Option #3:
+
+This memo includes no request to IANA.
+
+== Contributors
+
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC2578,RFC 2578]]]
+* [[[RFC2579,RFC 2579]]]
+* [[[RFC2580,RFC 2580]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC2223,RFC 2223]]]
+* [[[RFC3410,RFC 3410]]]
+* [[[RFC2629,RFC 2629]]]
+* [[[RFC4181,RFC 4181]]]
+* [[[idguidelines]]] IETF Internet Drafts editor, http://www.ietf.org/ietf/1id-guidelines.txt.
+* [[[idnits]]] IETF Internet Drafts editor, http://www.ietf.org/ID-Checklist.html.
+* [[[xml2rfc]]] XML2RFC tools and documentation, http://xml.resource.org.
+* [[[ops]]] the IETF OPS Area, http://www.ops.ietf.org.
+* [[[ietf]]] IETF Tools Team, http://tools.ietf.org.
+
+[[appendix]]
+== Change Log
+Note to RFC Editor: if this document does not obsolete an existing RFC, 
+please remove this appendix before publication as an RFC.
+
+== Open Issues
+Note to RFC Editor: please remove this appendix before publication as an RFC.

--- a/sources/refs-v2/document.adoc
+++ b/sources/refs-v2/document.adoc
@@ -1,0 +1,43 @@
+= vCard Format Specification
+Simon Perreault <simon.perreault@viagenie.ca>
+:doctype: rfc
+:obsoletes: RFC 2425;RFC 2426;RFC 4770
+:updates: RFC 2739
+:name: rfc-6350
+:docnumber: 6350
+:revdate: 2011-08-31
+:submission-type: IETF
+:status: standard
+:intended-series: full-standard 6350
+:fullname: Simon Perreault
+:surname: Perreault
+:givenname: Simon
+:initials: S.
+:organization: Viagenie
+:email: simon.perreault@viagenie.ca
+:street: 2875 Laurier, suite D2-630
+:region: Quebec, QC
+:code: G1V 2M2
+:country: Canada
+:phone: +1 418 656 9254
+:uri: http://www.viagenie.ca
+:link: urn:issn:2070-1721 item
+
+== Introduction
+The authors would like to thank Tim Howes, Mark Smith, and Frank
+Dawson, the original authors of <<RFC2119>> and <<RFC2629>>, Pete
+Resnick, who got this effort started and provided help along the way,
+as well as the following individuals who have participated in the
+drafting, review, and discussion of this memo.
+<<RFC2119,RFC 2119>>
+<<RFC2119,format=counter: RFC 2119>>
+
+[bibliography]
+== Normative References
+
+* [[[RFC2629,RFC 2629]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC2119,RFC 2119]]]

--- a/sources/refs-v3/document.adoc
+++ b/sources/refs-v3/document.adoc
@@ -1,0 +1,54 @@
+= vCard Format Specification
+Simon Perreault <simon.perreault@viagenie.ca>
+:doctype: rfc
+:abbrev: IP Datagrams on Avian Carriers
+:obsoletes: RFC 10;RFC 120
+:updates: RFC 2010;RFC 2120
+:name: rfc-1149
+:docnumber: 1149
+:status: full-standard 1149
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:keyword: this, that
+:revdate: 1990-04-01T00:00:00Z
+:fullname: Simon Perreault
+:surname: Perreault
+:givenname: Simon
+:initials: S.
+:email: simon.perreault@viagenie.ca
+:organization: BBN STC
+:phone: (617) 873-4323
+:uri: http://bbn.com
+:street: 10 Moulton Street
+:city: Cambridge
+:code: MA 02238
+:organization_2: BBN STC
+:phone_2: (617) 873-4323
+:street_2: 10 Moulton Street
+:city_2: Cambridge
+:code_2: MA 02238
+:uri_2: http://opoudjis.net
+:link: http://example1.com,http://example2.com author
+
+== Introduction
+The authors would like to thank Tim Howes, Mark Smith, and Frank
+Dawson, the original authors of <<RFC2119>> and <<RFC2629>>, Pete
+Resnick, who got this effort started and provided help along the way,
+as well as the following individuals who have participated in the
+drafting, review, and discussion of this memo:
+<<RFC2119,RFC 2119>> 0
+<<RFC2119,format=counter: RFC 2119>> 1
+<<RFC2119,section=2.4>> 2
+<<RFC2119,section=2.4>> 3
+
+[bibliography]
+== Normative References
+
+* [[[RFC2629,RFC 2629]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC3552_5226]]] Rescorla, E. and B. Korver, "Guidelines for Writing RFC Text on Security Considerations", BCP 72, RFC 3552, July 2003; Narten, T. and H. Alvestrand, "Guidelines for Writing an IANA Considerations Section in RFCs", RFC 5226, May 2008.

--- a/sources/refs-v3/document.adoc
+++ b/sources/refs-v3/document.adoc
@@ -7,6 +7,7 @@ Simon Perreault <simon.perreault@viagenie.ca>
 :name: rfc-1149
 :docnumber: 1149
 :status: full-standard 1149
+:intended-series: full-standard 1149
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group

--- a/sources/rfc1149/document.adoc
+++ b/sources/rfc1149/document.adoc
@@ -1,0 +1,70 @@
+= A Standard for the Transmission of IP Datagrams on Avian Carriers
+David Waitzman <dwaitzman@BBN.COM>
+:doctype: rfc
+:abbrev: IP Datagrams on Avian Carriers
+:status: info
+:name: rfc-1149
+:docnumber: 1149
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 1990-04-01T00:00:00Z
+:fullname: David Waitzman
+:surname: Waitzman
+:givenname: David
+:initials: D.
+:email: dwaitzman@BBN.COM
+:organization: BBN STC
+:street: 10 Moulton Street
+:city: Cambridge
+:code: MA 02238
+:smart-quotes: false
+
+[[overview-and-rational]]
+== Overview and Rational
+
+Avian carriers can provide high delay, low throughput, and low
+altitude service.  The connection topology is limited to a single
+point-to-point path for each carrier, used with standard carriers,
+but many carriers can be used without significant interference with
+each other, outside of early spring.  This is because of the 3D ether
+space available to the carriers, in contrast to the 1D ether used by
+IEEE802.3.  The carriers have an intrinsic collision avoidance
+system, which increases availability.  Unlike some network
+technologies, such as packet radio, communication is not limited to
+line-of-sight distance.  Connection oriented service is available in
+some cities, usually based upon a central hub topology.
+
+[[frame-format]]
+== Frame Format
+
+The IP datagram is printed, on a small scroll of paper, in
+hexadecimal, with each octet separated by whitestuff and blackstuff.
+The scroll of paper is wrapped around one leg of the avian carrier.
+A band of duct tape is used to secure the datagram's edges.  The
+bandwidth is limited to the leg length.  The MTU is variable, and
+paradoxically, generally increases with increased carrier age.  A
+typical MTU is 256 milligrams.  Some datagram padding may be needed.
+
+Upon receipt, the duct tape is removed and the paper copy of the
+datagram is optically scanned into a electronically transmittable
+form.
+
+[[discussion]]
+== Discussion
+
+Multiple types of service can be provided with a prioritized pecking
+order.  An additional property is built-in worm detection and
+eradication.  Because IP only guarantees best effort delivery, loss
+of a carrier can be tolerated.  With time, the carriers are self-
+regenerating.  While broadcasting is not specified, storms can cause
+data loss.  There is persistent delivery retry, until the carrier
+drops.  Audit trails are automatically generated, and can often be
+found on logs and cable trays.
+
+[[security-considerations]]
+== Security Considerations
+
+Security is not generally a problem in normal operation, but special
+measures must be taken (such as data encryption) when avian carriers
+are used in a tactical environment.

--- a/sources/rfc1149/document.adoc
+++ b/sources/rfc1149/document.adoc
@@ -3,6 +3,7 @@ David Waitzman <dwaitzman@BBN.COM>
 :doctype: rfc
 :abbrev: IP Datagrams on Avian Carriers
 :status: info
+:intended-series: informational
 :name: rfc-1149
 :docnumber: 1149
 :ipr: trust200902

--- a/sources/rfc2100/document.adoc
+++ b/sources/rfc2100/document.adoc
@@ -1,0 +1,125 @@
+= The Naming of Hosts
+Jay R. Ashworth <jra@scfn.thpl.lib.fl.us>
+:doctype: internet-draft
+:abbrev: The Naming of Hosts
+:status: info
+:name: rfc-2100
+:docnumber: 2100
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 1997-04-01T00:00:00Z
+:fullname: Jay R. Ashworth
+:surname: Ashworth
+:givenname: Jay
+:initials: J. R.
+:email: jra@scfn.thpl.lib.fl.us
+:organization_abbrev: Ashworth & Associates
+:organization: Advanced Technology Consulting
+:phone: +1 813 790 7592
+:city: St. Petersburg
+:code: FL 33709-4819
+:sym-refs: false
+:toc-include: false
+:smart-quotes: false
+
+
+[[introduction]]
+== Introduction
+
+This RFC is a commentary on the difficulty of deciding upon an
+acceptably distinctive hostname for one's computer, a problem which
+grows in direct proportion to the logarithmically increasing size of
+the Internet.
+
+Distribution of this memo is unlimited.
+
+Except to TS Eliot.
+
+And, for that matter, to David Addison, who hates iambic pentameter.
+
+[[poetry]]
+== Poetry
+
+....
+The Naming of Hosts is a difficult matter,
+    It isn't just one of your holiday games;
+You may think at first I'm as mad as a hatter
+    When I tell you, a host must have THREE DIFFERENT NAMES.
+....
+
+....
+First of all, there's the name that the users use daily,
+    Such as venus, athena, and cisco, and ames,
+Such as titan or sirius, hobbes or europa--
+    All of them sensible everyday names.
+....
+
+....
+There are fancier names if you think they sound sweeter,
+    Some for the web pages, some for the flames:
+Such as mercury, phoenix, orion, and charon--
+    But all of them sensible everyday names.
+....
+
+....
+But I tell you, a host needs a name that's particular,
+    A name that's peculiar, and more dignified,
+Else how can it keep its home page perpendicular,
+    And spread out its data, send pages world wide?
+....
+
+....
+Of names of this kind, I can give you a quorum,
+    Like lothlorien, pothole, or kobyashi-maru,
+Such as pearly-gates.vatican, or else diplomatic-
+    Names that never belong to more than one host.
+....
+
+....
+But above and beyond there's still one name left over,
+    And that is the name that you never will guess;
+The name that no human research can discover--
+    But THE NAMESERVER KNOWS, and will us'ually confess.
+....
+
+....
+When you notice a client in rapt meditation,
+    The reason, I tell you, is always the same:
+The code is engaged in a deep consultation
+    On the address, the address, the address of its name:
+....
+
+....
+            It's ineffable,
+            effable,
+            Effanineffable,
+            Deep and inscrutable,
+            singular
+            Name.
+....
+
+[[credits]]
+== Credits
+
+Thanks to Don Libes, Mark Lottor, and a host of twisted
+individuals^W^Wcreative sysadmins for providing source material for
+this memo, to Andrew Lloyd-Webber, Cameron Mackintosh, and a cast of
+thousands (particularly including Terrance Mann) who drew my
+attention to the necessity, and of course, to Thomas Stearns Eliot,
+for making this all necessary.
+
+[[security-considerations]]
+== Security Considerations
+
+Security issues are not discussed in this memo.
+
+Particularly the cardiac security of certain famous poets.
+
+[bibliography]
+== Informative References
+
+* [[[libes]]] Libes, D., "Choosing a Name for Your Computer", Communications of the ACM, Vol. 32, No. 11, Pg. 1289, November 1989.
+* [[[lottor]]] Lottor, M., "Domain Name Survey", namedroppers@internic.net, January 1997.
+* [[[ts]]] Stearns, T.S., "Old Possum's Book of Practical Cats".
+* [[[wong]]] Wong, M., "Cool Hostnames", http://www.seas.upenn.edu/~mengwong/coolhosts.html.

--- a/sources/rfc2100/document.adoc
+++ b/sources/rfc2100/document.adoc
@@ -3,6 +3,7 @@ Jay R. Ashworth <jra@scfn.thpl.lib.fl.us>
 :doctype: internet-draft
 :abbrev: The Naming of Hosts
 :status: info
+:intended-series: informational
 :name: rfc-2100
 :docnumber: 2100
 :ipr: trust200902

--- a/sources/rfc3514/document.adoc
+++ b/sources/rfc3514/document.adoc
@@ -3,6 +3,7 @@ Steven M. Bellovin <bellovin@acm.org>
 :doctype: internet-draft
 :abbrev: The Security Flag in the IPv4 Header
 :status: info
+:intended-series: informational
 :name: rfc-3514
 :ipr: trust200902
 :area: Internet

--- a/sources/rfc3514/document.adoc
+++ b/sources/rfc3514/document.adoc
@@ -1,0 +1,207 @@
+= The Security Flag in the IPv4 Header
+Steven M. Bellovin <bellovin@acm.org>
+:doctype: internet-draft
+:abbrev: The Security Flag in the IPv4 Header
+:status: info
+:name: rfc-3514
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 2003-04-01T00:00:00Z
+:fullname: Steven M. Bellovin
+:surname: Bellovin
+:givenname: Steven
+:initials: S. M.
+:email: bellovin@acm.org
+:organization: AT&T Labs Research
+:phone: +1 973-360-8656
+:street: 180 Park Avenue
+:city: Florham Park
+:code: NJ 07932
+:smart-quotes: false
+:inline-definition-lists: true
+
+Firewalls, packet filters, intrusion detection systems, and the like
+often have difficulty distinguishing between packets that have
+malicious intent and those that are merely unusual.  We define a
+security flag in the IPv4 header as a means of distinguishing the two
+cases.
+
+[[introduction]]
+== Introduction
+
+Firewalls <<CBR03>>, packet filters, intrusion detection systems, and
+the like often have difficulty distinguishing between packets that
+have malicious intent and those that are merely unusual.  The problem
+is that making such determinations is hard.  To solve this problem,
+we define a security flag, known as the "evil" bit, in the IPv4
+<<RFC0791>> header.  Benign packets have this bit set to 0; those that
+are used for an attack will have the bit set to 1.
+
+[[terminology]]
+=== Terminology
+
+The keywords **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**,
+**SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL**, when they appear in this
+document, are to be interpreted as described in <<RFC2119>>.
+
+[[syntax]]
+== Syntax
+
+The high-order bit of the IP fragment offset field is the only unused
+bit in the IP header.  Accordingly, the selection of the bit position
+is not left to IANA.
+
+The bit field is laid out as follows:
+
+....
+     0
+    +-+
+    |E|
+    +-+
+....
+
+Currently-assigned values are defined as follows:
+
+0x0: :: 
++
+If the bit is set to 0, the packet has no evil intent.  Hosts,
+    network elements, etc., **SHOULD** assume that the packet is
+    harmless, and **SHOULD NOT** take any defensive measures.  (We note
+    that this part of the spec is already implemented by many common
+    desktop operating systems.)
+
+0x1: :: 
++
+If the bit is set to 1, the packet has evil intent.  Secure
+    systems **SHOULD** try to defend themselves against such packets.
+    Insecure systems **MAY** chose to crash, be penetrated, etc.
+
+[[setting-the-evil-bit]]
+== Setting the Evil Bit
+
+There are a number of ways in which the evil bit may be set.  Attack
+applications may use a suitable API to request that it be set.
+Systems that do not have other mechanisms **MUST** provide such an API;
+attack programs **MUST** use it.
+
+Multi-level insecure operating systems may have special levels for
+attack programs; the evil bit **MUST** be set by default on packets
+emanating from programs running at such levels.  However, the system
+_MAY_ provide an API to allow it to be cleared for non-malicious
+activity by users who normally engage in attack behavior.
+
+Fragments that by themselves are dangerous **MUST** have the evil bit
+set.  If a packet with the evil bit set is fragmented by an
+intermediate router and the fragments themselves are not dangerous,
+the evil bit **MUST** be cleared in the fragments, and **MUST** be turned
+back on in the reassembled packet.
+
+Intermediate systems are sometimes used to launder attack
+connections.  Packets to such systems that are intended to be relayed
+to a target SHOULD have the evil bit set.
+
+Some applications hand-craft their own packets.  If these packets are
+part of an attack, the application **MUST** set the evil bit by itself.
+
+In networks protected by firewalls, it is axiomatic that all
+attackers are on the outside of the firewall.  Therefore, hosts
+inside the firewall **MUST NOT** set the evil bit on any packets.
+
+Because NAT <<RFC3022>> boxes modify packets, they **SHOULD** set the evil
+bit on such packets.  "Transparent" http and email proxies **SHOULD** set
+the evil bit on their reply packets to the innocent client host.
+
+Some hosts scan other hosts in a fashion that can alert intrusion
+detection systems.  If the scanning is part of a benign research
+project, the evil bit **MUST NOT** be set.  If the scanning per se is
+innocent, but the ultimate intent is evil and the destination site
+has such an intrusion detection system, the evil bit **SHOULD** be set.
+
+[[processing-of-the-evil-bit]]
+== Processing of the Evil Bit
+
+Devices such as firewalls **MUST** drop all inbound packets that have the
+evil bit set.  Packets with the evil bit off **MUST NOT** be dropped.
+Dropped packets **SHOULD** be noted in the appropriate MIB variable.
+
+Intrusion detection systems (IDSs) have a harder problem.  Because of
+their known propensity for false negatives and false positives, IDSs
+**MUST** apply a probabilistic correction factor when evaluating the evil
+bit.  If the evil bit is set, a suitable random number generator
+<<RFC1750>> must be consulted to determine if the attempt should be
+logged.  Similarly, if the bit is off, another random number
+generator must be consulted to determine if it should be logged
+despite the setting.
+
+The default probabilities for these tests depends on the type of IDS.
+Thus, a signature-based IDS would have a low false positive value but
+a high false negative value.  A suitable administrative interface
+**MUST** be provided to permit operators to reset these values.
+
+Routers that are not intended as as security devices **SHOULD NOT**
+examine this bit. This will allow them to pass packets at higher
+speeds.
+
+As outlined earlier, host processing of evil packets is operating-
+system dependent; however, all hosts **MUST** react appropriately
+according to their nature.
+
+[[related-work]]
+== Related Work
+
+Although this document only defines the IPv4 evil bit, there are
+complementary mechanisms for other forms of evil.  We sketch some of
+those here.
+
+For IPv6 <<RFC2460>>, evilness is conveyed by two options.  The first,
+a hop-by-hop option, is used for packets that damage the network,
+such as DDoS packets.  The second, an end-to-end option, is for
+packets intended to damage destination hosts.  In either case, the
+option contains a 128-bit strength indicator, which says how evil the
+packet is, and a 128-bit type code that describes the particular type
+of attack intended.
+
+Some link layers, notably those based on optical switching, may
+bypass routers (and hence firewalls) entirely.  Accordingly, some
+link-layer scheme **MUST** be used to denote evil.  This may involve evil
+lambdas, evil polarizations, etc.
+
+DDoS attack packets are denoted by a special diffserv code point.
+
+An application/evil MIME type is defined for Web- or email-carried
+mischief.  Other MIME types can be embedded inside of evil sections;
+this permit easy encoding of word processing documents with macro
+viruses, etc.
+
+[[iana-considerations]]
+== IANA Considerations
+
+This document defines the behavior of security elements for the 0x0
+and 0x1 values of this bit.  Behavior for other values of the bit may
+be defined only by IETF consensus <<RFC2434>>.
+
+[[security-considerations]]
+== Security Considerations
+
+Correct functioning of security mechanisms depend critically on the
+evil bit being set properly.  If faulty components do not set the
+evil bit to 1 when appropriate, firewalls will not be able to do
+their jobs properly.  Similarly, if the bit is set to 1 when it
+shouldn't be, a denial of service condition may occur.
+
+
+[bibliography]
+== Normative References
+
+* [[[RFC0791,RFC 791]]]
+* [[[RFC1750,RFC 1750]]]
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC2434,RFC 2434]]]
+* [[[RFC2460,RFC 2460]]]
+* [[[RFC3022,RFC 3022]]]
+
+[bibliography]
+== Informative References
+
+* [[[CBR03]]] Cheswick, W.R., Bellovin, S.M., and A.D. Rubin, "Firewalls and Internet Security: Repelling the Wily Hacker, Second Edition", Addison-Wesley, 2003.

--- a/sources/rfc5841/document.adoc
+++ b/sources/rfc5841/document.adoc
@@ -1,0 +1,340 @@
+= TCP Option to Denote Packet Mood
+Richard Hay <rhay@google.com>; Warren Turkal <turkal@google.com>
+:doctype: internet-draft
+:abbrev: TCP Option to Denote Packet Mood
+:status: info
+:name: rfc-5841
+:docnumber: 5841
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 2010-04-01T00:00:00Z
+:fullname: Richard Hay
+:surname: Hay
+:givenname: Richard
+:initials: R.
+:email: rhay@google.com
+:organization: Google
+:street: 1600 Amphitheatre Pkwy
+:city: Mountain View
+:code: CA 94043
+:toc-include: false
+:fullname_2: Warren Turkal
+:surname_2: Turkal
+:givenname_2: Warren
+:initials_2: W.
+:email_2: turkal@google.com
+:organization_2: Google
+:street_2: 1600 Amphitheatre Pkwy
+:city_2: Mountain View
+:code_2: CA 94043
+
+This document proposes a new TCP option to denote packet mood.
+
+== Introduction
+
+In an attempt to anthropomorphize the bit streams on countless
+physical layer networks throughout the world, we propose a TCP option
+to express packet mood <<DSM-IV>>.
+
+Packets cannot feel.  They are created for the purpose of moving data
+from one system to another.  However, it is clear that in specific
+situations some measure of emotion can be inferred or added.  For
+instance, a packet that is retransmitted to resend data for a packet
+for which no ACK was received could be described as an 'angry'
+packet, or a 'frustrated' packet (if it is not the first
+retransmission for instance).  So how can these kinds of feelings be
+conveyed in the packets themselves.  This can be addressed by adding
+TCP Options <<RFC0793>> to the TCP header, using ASCII characters that
+encode commonly used "emoticons" to convey packet mood.
+
+=== Terminology
+
+The keywords **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**,
+**SHOULD NOT**, **RECOMMENDED**, **MAY**, and **OPTIONAL**, when they appear in this
+document, are to be interpreted as described in <<RFC2119>>.
+
+== Syntax
+
+A TCP Option has a 1-byte kind field, followed by a 1-byte length
+field <<RFC0793>>.  It is proposed that option 25 (released 2000-12-18)
+be used to define packet mood.  This option would have a length value
+of 4 or 5 bytes.  All the simple emotions described as expressible
+via this mechanism can be displayed with two or three 7-bit, ASCII-
+encoded characters.  Multiple mood options may appear in a TCP
+header, so as to express more complex moods than those defined here
+(for instance if a packet were happy and surprised).
+
+.TCP Header Format
+====
+[align=center]
+....
+    Kind     Length     Meaning
+    ----     --------   -------
+     25      Variable   Packet Mood
+....
+====
+
+In more detail:
+
+[align=left]
+....
+       +--------+--------+--------+--------+
+       |00011001|00000100|00111010|00101001|
+       +--------+--------+--------+--------+
+        Kind=25  Length=4 ASCII :  ASCII )
+
+       +--------+--------+--------+--------+--------+
+       |00011001|00000101|00111110|00111010|01000000|
+       +--------+--------+--------+--------+--------+
+        Kind=25  Length=5 ASCII >  ACSII :  ASCII @
+....
+
+[[simple-emotional-representation]]
+== Simple Emotional Representation
+
+It is proposed that common emoticons be used to denote packet mood.
+Packets do not "feel" per se.  The emotions they could be tagged with
+are a reflection of the user mood expressed through packets.
+
+So the humanity expressed in a packet would be entirely sourced from
+humans.
+
+To this end, it is proposed that simple emotions be used convey mood
+as follows.
+
+....
+  ASCII                Mood
+  =====                ====
+  :)                   Happy
+  :(                   Sad
+  :D                   Amused
+  %(                   Confused
+  :o                   Bored
+  :O                   Surprised
+  :P                   Silly
+  :@                   Frustrated
+  >:@                  Angry
+  :|                   Apathetic
+  ;)                   Sneaky
+  >:)                  Evil
+....
+
+Proposed ASCII character encoding
+
+....
+  Binary          Dec  Hex     Character
+  ========        ===  ===     =========
+  010 0101        37   25      %
+  010 1000        40   28      (
+  010 1001        41   29      )
+  011 1010        58   3A      :
+  011 1011        59   3B      ;
+  011 1110        62   3E      >
+  100 0000        64   40      @
+  100 0100        68   44      D
+  100 1111        79   4F      O
+  101 0000        80   50      P
+  110 1111        111  6F      o
+  111 1100        124  7C      |
+....
+
+For the purposes of this RFC, 7-bit ASCII encoding is sufficient for
+representing emoticons.  The ASCII characters will be sent in 8-bit
+bytes with the leading bit always set to 0.
+
+== Use Cases
+
+There are two ways to denote packet mood.  One is to infer the mood
+based on an event in the TCP session.  The other is to derive mood
+from a higher-order action at a higher layer (subject matter of
+payload for instance).
+
+For packets where the 'mood' is inferred from activity within the TCP
+session, the 'mood' **MUST** be set by the host that is watching for the
+trigger event.  If a client sends a frame and receives no ACK, then
+the retransmitted frame **MAY** contain the TCP OPTION header with a mood
+set.
+
+Any packet that exhibits behavior that allows for mood to be inferred
+**SHOULD** add the TCP OPTION to the packets with the implied mood.
+
+Applications can take advantage of the defined moods by expressing
+them in the packets.  This can be done in the SYN packet sent from
+the client.  All packets in the session can be then tagged with the
+mood set in the SYN packet, but this would have a per-packet
+performance cost (see <<performance-considerations>> "Performance Considerations").
+
+Each application **MUST** define the preconditions for marking packets as
+happy, sad, bored, confused, angry, apathetic, and so on.  This is a
+framework for defining how such moods can be expressed, but it is up
+to the developers to determine when to apply these encoded labels.
+
+=== Happy Packets
+
+Healthy packets are happy packets you could say.  If the ACK packets
+return within <10 ms end-to-end from a sender's stack to a receiver's
+stack and back again, this would reflect high-speed bidirectional
+capability, and if no retransmits are required and all ACKs are
+received, all subsequent packets in that session **SHOULD** be marked as
+'happy'.
+
+No loss, low-latency packets also makes for happy users.  So the
+packet would be reflecting the end-user experience.
+
+=== Sad Packets
+
+If retransmission rates achieve greater than 20% of all packets sent
+in a session, it is fair to say the session can be in mourning for
+all of the good packets lost in the senseless wasteland of the wild
+Internet.
+
+This should not be confused with retransmitted packets marked as
+'angry' since this tag would apply to all frames in the session
+numbed by the staggering loss of packet life.
+
+=== Amused Packets
+
+Any packet that is carrying a text joke **SHOULD** be marked as 'amused'.
+
+Example:
+
+....
+  1: Knock Knock
+  2: Who's there?
+  1: Impatient chicken
+  2: Impatient chi...
+  1: BAWK!!!!
+....
+
+If such a joke is in the packet payload then, honestly, how can you
+not be amused by one of the only knock-knock jokes that survives the
+3rd grade?
+
+=== Confused Packets
+
+When is a packet confused?  There are network elements that perform
+per-packet load balancing, and if there are asymmetries in the
+latencies between end-to-end paths, out-of-order packet delivery can
+occur.
+
+When a receiver host gets out-of-order packets, it **SHOULD** mark TCP
+ACK packets sent back to the sender as confused.
+
+The same can be said for packets that are sent to incorrect VLAN
+segments or are misdirected.  The receivers might be aware that the
+packet is confused, but there is no way to know at ingress if that
+will be the fate of the frame.
+
+That being said, application developers **SHOULD** mark packets as
+confused if the payload contains complex philosophical questions that
+make one ponder the meaning of life and one's place in the universe.
+
+=== Bored Packets
+
+Packets carrying accounting data with debits, credits, and so on **MUST**
+be marked as 'bored'.
+
+It could be said that many people consider RFCs boring.  Packets
+containing RFC text **MAY** be marked as 'bored'.
+
+Packets with phone book listings **MUST** be marked 'bored'.
+
+Packets containing legal disclaimers and anything in Latin **SHOULD** be
+marked 'bored'.
+
+=== Surprised Packets
+
+Who doesn't love when the out-of-order packets in your session
+surprise you while waiting in a congested queue for 20 ms?
+
+Packets do not have birthdays, so packets can be marked as surprised
+when they encounter unexpected error conditions.
+
+So when ICMP destination unreachable messages are received (perhaps
+due to a routing loop or congestion discards), all subsequent packets
+in that session **SHOULD** be marked as surprised.
+
+=== Silly Packets
+
+Not all packets are sent as part of a session.  Random keepalives
+during a TCP session **MAY** be set up as a repartee between systems
+connected as client and server.  Such random and even playful
+interchanges **SHOULD** be marked as silly.
+
+=== Frustrated Packets
+
+Packets that are retransmitted more than once **SHOULD** be marked as
+frustrated.
+
+=== Angry Packets
+
+Packets that are retransmitted **SHOULD** be marked as angry.
+
+=== Apathetic Packets
+
+When sending a RST packet to a connected system, the packet should be
+marked as apathetic so that the receiver knows that your system does
+not care what happens after that.
+
+===  Sneaky Packets
+
+When a packet is used in a particularly clever way, it **SHOULD** be
+marked as sneaky.  What is "clever" is rather subjective, so it would
+be prudent to get a few opinions about a particular use to make sure
+that it is clever.
+
+=== Evil Packets
+
+It is hard for a TCP packet to discern higher moral quandaries like
+the meaning of life or what exactly defines 'evil' and from whose
+perspective such a characterization is being made.  However,
+developers of TCP-based applications **MAY** choose to see some
+activities as evil when viewed through their particular lens of the
+world.  At that point, they **SHOULD** mark packets as evil.
+
+Some organizations are prohibited from using this mood by mission
+statement.  This would also prohibit using the security flag in the
+IP header described in <<RFC3514>> for the same reasons.
+
+[[performance-considerations]]
+== Performance Considerations
+
+Adding extensions to the TCP header has a cost.  Using TCP extensions
+with the ASCII-encoded mood of the packet would detract from the
+available MSS usable for data payload.  If the TCP header is more
+than 20 bytes, then the extra bytes would be unavailable for use in
+the payload of the frame.
+
+This added per-packet overhead should be considered when using packet
+mood extensions.
+
+== Security Considerations
+
+The TCP checksum, as a 16-bit value, could be mistaken if ASCII
+characters with the same number of zeros and ones were substituted
+out.  A happy `:)` could be replaced with a frown by a malicious
+attacker, by using a winking eye `;(`.  This could misrepresent the
+intended mood of the sender to the receiver.
+
+== Related Work
+
+This document does not seek to build a sentient network stack.
+However, this framework could be used to express the emotions of a
+sentient stack.  If that were to happen, a new technical job class of
+network psychologists could be created.  Who doesn't like new jobs? :)
+
+== IANA Considerations
+
+If this work is standardized, IANA is requested to officially assign
+value 25 as described in <<simple-emotional-representation>>.  Additional moods and emoticon
+representations would require IESG approval or standards action <<RFC5226>>.
+
+[bibliography]
+== Informative References
+
+* [[[RFC0793,RFC 793]]]
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC3514,RFC 3514]]]
+* [[[RFC5226,RFC 5226]]]
+* [[[DSM-IV]]] "Diagnostic and Statistical Manual of Mental Disorders (DSM)", http://www.psychiatryonline.com/resourceTOC.aspx?resourceID=1.

--- a/sources/rfc5841/document.adoc
+++ b/sources/rfc5841/document.adoc
@@ -3,6 +3,7 @@ Richard Hay <rhay@google.com>; Warren Turkal <turkal@google.com>
 :doctype: internet-draft
 :abbrev: TCP Option to Denote Packet Mood
 :status: info
+:intended-series: informational
 :name: rfc-5841
 :docnumber: 5841
 :ipr: trust200902

--- a/sources/rfc6350/document.adoc
+++ b/sources/rfc6350/document.adoc
@@ -1,0 +1,3537 @@
+= vCard Format Specification
+Simon Perreault <simon.perreault@viagenie.ca>
+:doctype: rfc
+:abbrev: vCard
+:obsoletes: RFC 2425;RFC 2426;RFC 4770
+:updates: RFC 2739
+:name: 6350
+:docnumber: 6350
+:revdate: 2011-08
+:submission-type: IETF
+:status: standard
+:intended-series: full-standard 6350
+:fullname: Simon Perreault
+:surname: Perreault
+:givenname: Simon
+:initials: S.
+:organization: Viagenie
+:email: simon.perreault@viagenie.ca
+:street: 2875 Laurier, suite D2-630
+:region: Quebec, QC
+:code: G1V 2M2
+:country: Canada
+:phone: +1 418 656 9254
+:uri: http://www.viagenie.ca
+:link: urn:issn:2070-1721 item
+:rfcedstyle: yes
+:ipr: pre5378Trust200902
+:inline-definition-lists: true
+:comments: yes
+
+This document defines the vCard data format for representing and
+exchanging a variety of information about individuals and other
+entities (e.g., formatted and structured name and delivery addresses,
+email address, multiple telephone numbers, photograph, logo, audio
+clips, etc.).  This document obsoletes RFCs 2425, 2426, and 4770, and
+updates RFC 2739.
+
+
+[[section1]]
+== Introduction
+
+Electronic address books have become ubiquitous.  Their increased
+presence on portable, connected devices as well as the diversity of
+platforms that exchange contact data call for a standard.  This memo
+defines the vCard format, which allows the capture and exchange of
+information normally stored within an address book or directory
+application.
+
+A high-level overview of the differences from RFCs 2425 and 2426 can
+be found in <<appendixA>>.
+
+[[section2]]
+== Conventions
+
+The key words "[bcp14]#MUST#", "[bcp14]#MUST NOT#", "[bcp14]#REQUIRED#", "[bcp14]#SHALL#", "[bcp14]#SHALL NOT#",
+"[bcp14]#SHOULD#", "[bcp14]#SHOULD NOT#", "[bcp14]#RECOMMENDED#", "[bcp14]#NOT RECOMMENDED#", "[bcp14]#MAY#", and
+"[bcp14]#OPTIONAL#" in this document are to be interpreted as described in
+<<RFC2119>>.
+
+[[section3]]
+== vCard Format Specification
+
+The text/vcard MIME content type (hereafter known as "vCard"; see
+<<section10_1>>) contains contact information, typically pertaining to a
+single contact or group of contacts.  The content consists of one or
+more lines in the format given below.
+
+[[section3_1]]
+=== Charset
+
+The charset (see <<RFC3536>> for internationalization terminology) for
+vCard is UTF-8 as defined in <<RFC3629>>.  There is no way to override
+this.  It is invalid to specify a value other than "UTF-8" in the
+"charset" MIME parameter (see <<section10_1>>).
+
+[[section3_2]]
+===  Line Delimiting and Folding
+
+Individual lines within vCard are delimited by the <<RFC5322>> line
+break, which is a CRLF sequence (U+000D followed by U+000A).  Long
+logical lines of text can be split into a multiple-physical-line
+representation using the following folding technique.  Content lines
+[bcp14]#SHOULD# be folded to a maximum width of 75 octets, excluding the line
+break.  Multi-octet characters [bcp14]#MUST# remain contiguous.  The rationale
+for this folding process can be found in <<RFC5322,section=2.1.1>>.
+
+A logical line [bcp14]#MAY# be continued on the next physical line anywhere
+between two characters by inserting a CRLF immediately followed by a
+single white space character (space (U+0020) or horizontal tab
+(U+0009)).  The folded line [bcp14]#MUST# contain at least one character.  Any
+sequence of CRLF followed immediately by a single white space
+character is ignored (removed) when processing the content type.  For
+example, the line:
+
+....
+  NOTE:This is a long description that exists on a long line.
+....
+
+can be represented as:
+
+....
+  NOTE:This is a long description
+    that exists on a long line.
+....
+
+It could also be represented as:
+
+....
+  NOTE:This is a long descrip
+   tion that exists o
+   n a long line.
+....
+
+The process of moving from this folded multiple-line representation
+of a property definition to its single-line representation is called
+unfolding.  Unfolding is accomplished by regarding CRLF immediately
+followed by a white space character (namely, HTAB (U+0009) or SPACE
+(U+0020)) as equivalent to no characters at all (i.e., the CRLF and
+single white space character are removed).
+
+Note: It is possible for very simple implementations to generate
+improperly folded lines in the middle of a UTF-8 multi-octet
+sequence.  For this reason, implementations [bcp14]#SHOULD# unfold lines in
+such a way as to properly restore the original sequence.
+
+Note: Unfolding is done differently than in <<RFC5322>>.  Unfolding
+in <<RFC5322>> only removes the CRLF, not the space following it.
+
+Folding is done after any content encoding of a type value.
+Unfolding is done before any decoding of a type value in a content
+line.
+
+[[section3_3]]
+=== ABNF Format Definition
+
+The following ABNF uses the notation of <<RFC5234>>, which also defines
+CRLF, WSP, DQUOTE, VCHAR, ALPHA, and DIGIT.
+
+[source,abnf]
+----
+vcard-entity = 1*vcard
+
+vcard = "BEGIN:VCARD" CRLF
+        "VERSION:4.0" CRLF
+        1*contentline
+        "END:VCARD" CRLF
+  ; A vCard object MUST include the VERSION and FN properties.
+  ; VERSION MUST come immediately after BEGIN:VCARD.
+
+contentline = [group "."] name *(";" param) ":" value CRLF
+  ; When parsing a content line, folded lines must first
+  ; be unfolded according to the unfolding procedure
+  ; described in Section 3.2.
+  ; When generating a content line, lines longer than 75
+  ; characters SHOULD be folded according to the folding
+  ; procedure described in Section 3.2.
+
+group = 1*(ALPHA / DIGIT / "-")
+name  = "SOURCE" / "KIND" / "FN" / "N" / "NICKNAME"
+      / "PHOTO" / "BDAY" / "ANNIVERSARY" / "GENDER" / "ADR" / "TEL"
+      / "EMAIL" / "IMPP" / "LANG" / "TZ" / "GEO" / "TITLE" / "ROLE"
+      / "LOGO" / "ORG" / "MEMBER" / "RELATED" / "CATEGORIES"
+      / "NOTE" / "PRODID" / "REV" / "SOUND" / "UID" / "CLIENTPIDMAP"
+      / "URL" / "KEY" / "FBURL" / "CALADRURI" / "CALURI" / "XML"
+      / iana-token / x-name
+  ; Parsing of the param and value is based on the "name" as
+  ; defined in ABNF sections below.
+  ; Group and name are case-insensitive.
+
+iana-token = 1*(ALPHA / DIGIT / "-")
+  ; identifier registered with IANA
+
+x-name = "x-" 1*(ALPHA / DIGIT / "-")
+  ; Names that begin with "x-" or "X-" are
+  ; reserved for experimental use, not intended for released
+  ; products, or for use in bilateral agreements.
+
+param = language-param / value-param / pref-param / pid-param
+      / type-param / geo-parameter / tz-parameter / sort-as-param
+      / calscale-param / any-param
+  ; Allowed parameters depend on property name.
+
+param-value = *SAFE-CHAR / DQUOTE *QSAFE-CHAR DQUOTE
+
+any-param  = (iana-token / x-name) "=" param-value *("," param-value)
+
+NON-ASCII = UTF8-2 / UTF8-3 / UTF8-4
+  ; UTF8-{2,3,4} are defined in [RFC3629]
+
+QSAFE-CHAR = WSP / "!" / %x23-7E / NON-ASCII
+  ; Any character except CTLs, DQUOTE
+
+SAFE-CHAR = WSP / "!" / %x23-39 / %x3C-7E / NON-ASCII
+  ; Any character except CTLs, DQUOTE, ";", ":"
+
+VALUE-CHAR = WSP / VCHAR / NON-ASCII
+  ; Any textual character
+----
+
+A line that begins with a white space character is a continuation of
+the previous line, as described in <<section3_2>>.  The white space
+character and immediately preceeding CRLF should be discarded when
+reconstructing the original line.  Note that this line-folding
+convention differs from that found in <<RFC5322>>, in that the sequence
+<CRLF><WSP> found anywhere in the content indicates a continued line
+and should be removed.
+
+Property names and parameter names are case-insensitive (e.g., the
+property name "fn" is the same as "FN" and "Fn").  Parameter values
+[bcp14]#MAY# be case-sensitive or case-insensitive, depending on their
+definition.  Parameter values that are not explicitly defined as
+being case-sensitive are case-insensitive.  Based on experience with
+vCard 3 interoperability, it is [bcp14]#RECOMMENDED# that property and
+parameter names be upper-case on output.
+
+The group construct is used to group related properties together.
+The group name is a syntactic convention used to indicate that all
+property names prefaced with the same group name [bcp14]#SHOULD# be grouped
+together when displayed by an application.  It has no other
+significance.  Implementations that do not understand or support
+grouping [bcp14]#MAY# simply strip off any text before a "." to the left of
+the type name and present the types and values as normal.
+
+Property cardinalities are indicated using the following notation,
+which is based on ABNF (see <<RFC5234,section=3.6>>):
+
+|===
+| Cardinality | Meaning                                         
+
+|      1      | Exactly one instance per vCard [bcp14]#MUST# be present.  
+|      *1     | Exactly one instance per vCard [bcp14]#MAY# be present.   
+|      1*     | One or more instances per vCard [bcp14]#MUST# be present. 
+|      *      | One or more instances per vCard [bcp14]#MAY# be present.  
+|===
+
+Properties defined in a vCard instance may have multiple values
+depending on the property cardinality.  The general rule for encoding
+multi-valued properties is to simply create a new content line for
+each value (including the property name).  However, it should be
+noted that some value types support encoding multiple values in a
+single content line by separating the values with a comma ",".  This
+approach has been taken for several of the content types defined
+below (date, time, integer, float).
+
+[[section3_4]]
+===  Property Value Escaping
+
+Some properties may contain one or more values delimited by a COMMA
+character (U+002C).  Therefore, a COMMA character in a value [bcp14]#MUST# be
+escaped with a BACKSLASH character (U+005C), even for properties that
+don't allow multiple instances (for consistency).
+
+Some properties (e.g., N and ADR) comprise multiple fields delimited
+by a SEMICOLON character (U+003B).  Therefore, a SEMICOLON in a field
+of such a "compound" property [bcp14]#MUST# be escaped with a BACKSLASH
+character.  SEMICOLON characters in non-compound properties [bcp14]#MAY# be
+escaped.  On input, an escaped SEMICOLON character is never a field
+separator.  An unescaped SEMICOLON character may be a field
+separator, depending on the property in which it appears.
+
+Furthermore, some fields of compound properties may contain a list of
+values delimited by a COMMA character.  Therefore, a COMMA character
+in one of a field's values [bcp14]#MUST# be escaped with a BACKSLASH
+character, even for fields that don't allow multiple values (for
+consistency).  Compound properties allowing multiple instances [bcp14]#MUST NOT#
+be encoded in a single content line.
+
+Finally, BACKSLASH characters in values [bcp14]#MUST# be escaped with a
+BACKSLASH character.  NEWLINE (U+000A) characters in values [bcp14]#MUST# be
+encoded by two characters: a BACKSLASH followed by either an 'n'
+(U+006E) or an 'N' (U+004E).
+
+In all other cases, escaping [bcp14]#MUST NOT# be used.
+
+[[section4]]
+==  Property Value Data Types
+
+Standard value types are defined below.
+
+[source,abnf]
+----
+  value = text
+        / text-list
+        / date-list
+        / time-list
+        / date-time-list
+        / date-and-or-time-list
+        / timestamp-list
+        / boolean
+        / integer-list
+        / float-list
+        / URI               ; from Section 3 of [RFC3986]
+        / utc-offset
+        / Language-Tag
+        / iana-valuespec
+    ; Actual value type depends on property name and VALUE parameter.
+
+  text = *TEXT-CHAR
+
+  TEXT-CHAR = "\\" / "\," / "\n" / WSP / NON-ASCII
+            / %x21-2B / %x2D-5B / %x5D-7E
+     ; Backslashes, commas, and newlines must be encoded.
+
+  component = "\\" / "\," / "\;" / "\n" / WSP / NON-ASCII
+            / %x21-2B / %x2D-3A / %x3C-5B / %x5D-7E
+  list-component = component *("," component)
+
+  text-list             = text             *("," text)
+  date-list             = date             *("," date)
+  time-list             = time             *("," time)
+  date-time-list        = date-time        *("," date-time)
+  date-and-or-time-list = date-and-or-time *("," date-and-or-time)
+  timestamp-list        = timestamp        *("," timestamp)
+  integer-list          = integer          *("," integer)
+  float-list            = float            *("," float)
+
+  boolean = "TRUE" / "FALSE"
+  integer = [sign] 1*DIGIT
+  float   = [sign] 1*DIGIT ["." 1*DIGIT]
+
+  sign = "+" / "-"
+
+  year   = 4DIGIT  ; 0000-9999
+  month  = 2DIGIT  ; 01-12
+  day    = 2DIGIT  ; 01-28/29/30/31 depending on month and leap year
+  hour   = 2DIGIT  ; 00-23
+  minute = 2DIGIT  ; 00-59
+  second = 2DIGIT  ; 00-58/59/60 depending on leap second
+  zone   = utc-designator / utc-offset
+  utc-designator = %x5A  ; uppercase "Z"
+
+  date          = year    [month  day]
+                / year "-" month
+                / "--"     month [day]
+                / "--"      "-"   day
+  date-noreduc  = year     month  day
+                / "--"     month  day
+                / "--"      "-"   day
+  date-complete = year     month  day
+
+  time          = hour [minute [second]] [zone]
+                /  "-"  minute [second]  [zone]
+                /  "-"   "-"    second   [zone]
+  time-notrunc  = hour [minute [second]] [zone]
+  time-complete = hour  minute  second   [zone]
+
+
+  time-designator = %x54  ; uppercase "T"
+  date-time = date-noreduc  time-designator time-notrunc
+  timestamp = date-complete time-designator time-complete
+
+  date-and-or-time = date-time / date / time-designator time
+
+  utc-offset = sign hour [minute]
+
+  Language-Tag = <Language-Tag, defined in [RFC5646], Section 2.1>
+
+  iana-valuespec = <value-spec, see Section 12>
+                 ; a publicly defined valuetype format, registered
+                 ; with IANA, as defined in Section 12 of this
+                 ; document.
+----
+
+[[section4_1]]
+===  TEXT
+
+"text": The "text" value type should be used to identify values that
+contain human-readable text.  As for the language, it is controlled
+by the LANGUAGE property parameter defined in <<section5_1>>.
+
+Examples for "text":
+
+....
+    this is a text value
+    this is one value,this is another
+    this is a single value\, with a comma encoded
+....
+
+A formatted text line break in a text value type [bcp14]#MUST# be represented
+as the character sequence backslash (U+005C) followed by a Latin
+small letter n (U+006E) or a Latin capital letter N (U+004E), that
+is, "\n" or "\N".
+
+For example, a multiple line NOTE value of:
+
+....
+    Mythical Manager
+    Hyjinx Software Division
+    BabsCo, Inc.
+....
+
+could be represented as:
+
+....
+    NOTE:Mythical Manager\nHyjinx Software Division\n
+     BabsCo\, Inc.\n
+....
+
+demonstrating the \n literal formatted line break technique, the
+CRLF-followed-by-space line folding technique, and the backslash
+escape technique.
+
+[[section4_2]]
+===  URI
+
+"uri": The "uri" value type should be used to identify values that
+are referenced by a Uniform Resource Identifier (URI) instead of
+encoded in-line.  These value references might be used if the value
+is too large, or otherwise undesirable to include directly.  The
+format for the URI is as defined in <<RFC3986,of,section=3>>.  Note
+that the value of a property of type "uri" is what the URI points to,
+not the URI itself.
+
+Examples for "uri":
+
+....
+    http://www.example.com/my/picture.jpg
+    ldap://ldap.example.com/cn=babs%20jensen
+....
+
+[[section4_3]]
+===  DATE, TIME, DATE-TIME, DATE-AND-OR-TIME, and TIMESTAMP
+
+"date", "time", "date-time", "date-and-or-time", and "timestamp":
+Each of these value types is based on the definitions in
+<<ISO.8601.2004>>.  Multiple such values can be specified using the
+comma-separated notation.
+
+Only the basic format is supported.
+
+[[section4_3_1]]
+====  DATE
+
+A calendar date as specified in <<ISO.8601.2004>>, Section 4.1.2.
+
+Reduced accuracy, as specified in <<ISO.8601.2004>>, Section 4.1.2.3 a)
+and b), but not c), is permitted.
+
+Expanded representation, as specified in <<ISO.8601.2004>>, Section 4.1.4, is forbidden.
+
+Truncated representation, as specified in <<ISO.8601.2000>>, Section 5.2.1.3 d), e), and f), is permitted.
+
+Examples for "date":
+
+....
+          19850412
+          1985-04
+          1985
+          --0412
+          ---12
+          
+          
+          
+....
+
+Note the use of YYYY-MM in the second example above.  YYYYMM is
+disallowed to prevent confusion with YYMMDD.  Note also that
+YYYY-MM-DD is disallowed since we are using the basic format instead
+of the extended format.
+
+[[section4_3_2]]
+====  TIME
+
+A time of day as specified in <<ISO.8601.2004>>, Section 4.2.
+
+Reduced accuracy, as specified in <<ISO.8601.2004>>, Section 4.2.2.3,
+is permitted.
+
+Representation with decimal fraction, as specified in
+<<ISO.8601.2004>>, Section 4.2.2.4, is forbidden.
+
+The midnight hour is always represented by 00, never 24 (see
+<<ISO.8601.2004>>, Section 4.2.3).
+
+Truncated representation, as specified in <<ISO.8601.2000>>, Section 5.3.1.4 a), b), and c), is permitted.
+
+Examples for "time":
+
+....
+          102200
+          1022
+          10
+          -2200
+          --00
+          102200Z
+          102200-0800
+....
+
+[[section4_3_3]]
+====  DATE-TIME
+
+A date and time of day combination as specified in <<ISO.8601.2004>>, Section 4.3.
+
+Truncation of the date part, as specified in <<ISO.8601.2000>>, Section 5.4.2 c), is permitted.
+
+Examples for "date-time":
+
+....
+          19961022T140000
+          --1022T1400
+          ---22T14
+....
+
+[[section4_3_4]]
+====  DATE-AND-OR-TIME
+
+Either a DATE-TIME, a DATE, or a TIME value.  To allow unambiguous
+interpretation, a stand-alone TIME value is always preceded by a "T".
+
+Examples for "date-and-or-time":
+
+....
+          19961022T140000
+          --1022T1400
+          ---22T14
+          19850412
+          1985-04
+          1985
+          --0412
+          ---12
+          T102200
+          T1022
+          T10
+          T-2200
+          T--00
+          T102200Z
+          T102200-0800
+....
+
+[[section4_3_5]]
+====  TIMESTAMP
+
+A complete date and time of day combination as specified in
+<<ISO.8601.2004>>, Section 4.3.2.
+
+Examples for "timestamp":
+
+....
+          19961022T140000
+          19961022T140000Z
+          19961022T140000-05
+          19961022T140000-0500
+....
+
+[[section4_4]]
+===  BOOLEAN
+
+"boolean": The "boolean" value type is used to express boolean
+values.  These values are case-insensitive.
+
+Examples: ::
+....
+    TRUE
+    false
+    True
+....
+
+
+[[section4_5]]
+===  INTEGER
+
+"integer": The "integer" value type is used to express signed
+integers in decimal format.  If sign is not specified, the value is
+assumed positive "+".  Multiple "integer" values can be specified
+using the comma-separated notation.  The maximum value is
+9223372036854775807, and the minimum value is -9223372036854775808.
+These limits correspond to a signed 64-bit integer using two's-
+complement arithmetic.
+
+Examples: ::
+....
+    1234567890
+    -1234556790
+    +1234556790,432109876
+....
+
+[[section4_6]]
+===  FLOAT
+
+"float": The "float" value type is used to express real numbers.  If
+sign is not specified, the value is assumed positive "+".  Multiple
+"float" values can be specified using the comma-separated notation.
+Implementations [bcp14]#MUST# support a precision equal or better than that of
+the IEEE "binary64" format <<IEEE.754.2008>>.
+
+Note: Scientific notation is disallowed.  Implementers wishing to
+use their favorite language's %f formatting should be careful.
+
+Examples: ::
+....
+    20.30
+    1000000.0000001
+    1.333,3.14
+....
+
+[[section4_7]]
+===  UTC-OFFSET
+
+"utc-offset": The "utc-offset" value type specifies that the property
+value is a signed offset from UTC.  This value type can be specified
+in the TZ property.
+
+The value type is an offset from Coordinated Universal Time (UTC).
+It is specified as a positive or negative difference in units of
+hours and minutes (e.g., +hhmm).  The time is specified as a 24-hour
+clock.  Hour values are from 00 to 23, and minute values are from 00
+to 59.  Hour and minutes are 2 digits with high-order zeroes required
+to maintain digit count.  The basic format for ISO 8601 UTC offsets
+[bcp14]#MUST# be used.
+
+[[section4_8]]
+===  LANGUAGE-TAG
+
+"language-tag": A single language tag, as defined in <<RFC5646>>.
+
+[[section5]]
+==  Property Parameters
+
+A property can have attributes associated with it.  These "property
+parameters" contain meta-information about the property or the
+property value.  In some cases, the property parameter can be multi-
+valued in which case the property parameter value elements are
+separated by a COMMA (U+002C).
+
+Property parameter value elements that contain the COLON (U+003A),
+SEMICOLON (U+003B), or COMMA (U+002C) character separators [bcp14]#MUST# be
+specified as quoted-string text values.  Property parameter values
+[bcp14]#MUST NOT# contain the DQUOTE (U+0022) character.  The DQUOTE character
+is used as a delimiter for parameter values that contain restricted
+characters or URI text.
+
+Applications [bcp14]#MUST# ignore x-param and iana-param values they don't
+recognize.
+
+[[section5_1]]
+=== LANGUAGE
+
+The LANGUAGE property parameter is used to identify data in multiple
+languages.  There is no concept of "default" language, except as
+specified by any "Content-Language" MIME header parameter that is
+present <<RFC3282>>.  The value of the LANGUAGE property parameter is a
+language tag as defined in <<RFC5646,of,section=2>>.
+
+Examples: ::
+....
+  ROLE;LANGUAGE=tr:hoca
+....
+
+ABNF: ::
+[source,abnf]
+----
+        language-param = "LANGUAGE=" Language-Tag
+          ; Language-Tag is defined in section 2.1 of RFC 5646
+          
+----
+
+[[section5_2]]
+===  VALUE
+
+The VALUE parameter is [bcp14]#OPTIONAL#, used to identify the value type
+(data type) and format of the value.  The use of these predefined
+formats is encouraged even if the value parameter is not explicitly
+used.  By defining a standard set of value types and their formats,
+existing parsing and processing code can be leveraged.  The
+predefined data type values [bcp14]#MUST NOT# be repeated in COMMA-separated
+value lists except within the N, NICKNAME, ADR, and CATEGORIES
+properties.
+
+ABNF: ::
+[source,abnf]
+----
+  value-param = "VALUE=" value-type
+
+  value-type = "text"
+             / "uri"
+             / "date"
+             / "time"
+             / "date-time"
+             / "date-and-or-time"
+             / "timestamp"
+             / "boolean"
+             / "integer"
+             / "float"
+             / "utc-offset"
+             / "language-tag"
+             / iana-token  ; registered as described in section 12
+             / x-name
+----
+
+[[section5_3]]
+===  PREF
+
+The PREF parameter is [bcp14]#OPTIONAL# and is used to indicate that the
+corresponding instance of a property is preferred by the vCard
+author.  Its value [bcp14]#MUST# be an integer between 1 and 100 that
+quantifies the level of preference.  Lower values correspond to a
+higher level of preference, with 1 being most preferred.
+
+When the parameter is absent, the default [bcp14]#MUST# be to interpret the
+property instance as being least preferred.
+
+Note that the value of this parameter is to be interpreted only in
+relation to values assigned to other instances of the same property
+in the same vCard.  A given value, or the absence of a value, [bcp14]#MUST NOT#
+be interpreted on its own.
+
+This parameter [bcp14]#MAY# be applied to any property that allows multiple
+instances.
+
+ABNF: ::
+[source,abnf]
+----
+        pref-param = "PREF=" (1*2DIGIT / "100")
+                             ; An integer between 1 and 100.
+----
+
+
+[[section5_4]]
+===  ALTID
+
+The ALTID parameter is used to "tag" property instances as being
+alternative representations of the same logical property.  For
+example, translations of a property in multiple languages generates
+multiple property instances having different LANGUAGE (<<section5_1>>)
+parameter that are tagged with the same ALTID value.
+
+This parameter's value is treated as an opaque string.  Its sole
+purpose is to be compared for equality against other ALTID parameter
+values.
+
+Two property instances are considered alternative representations of
+the same logical property if and only if their names as well as the
+value of their ALTID parameters are identical.  Property instances
+without the ALTID parameter [bcp14]#MUST NOT# be considered an alternative
+representation of any other property instance.  Values for the ALTID
+parameter are not globally unique: they [bcp14]#MAY# be reused for different
+property names.
+
+Property instances having the same ALTID parameter value count as 1
+toward cardinality.  Therefore, since N (<<section6_2_2>>) has
+cardinality *1 and TITLE (<<section6_6_1>>) has cardinality *, these
+three examples would be legal:
+
+....
+  N;ALTID=1;LANGUAGE=jp:<U+5C71><U+7530>;<U+592A><U+90CE>;;;
+  N;ALTID=1;LANGUAGE=en:Yamada;Taro;;;
+  (<U+XXXX> denotes a UTF8-encoded Unicode character.)
+....
+
+....
+  TITLE;ALTID=1;LANGUAGE=fr:Patron
+  TITLE;ALTID=1;LANGUAGE=en:Boss
+....
+
+....
+  TITLE;ALTID=1;LANGUAGE=fr:Patron
+  TITLE;ALTID=1;LANGUAGE=en:Boss
+  TITLE;ALTID=2;LANGUAGE=en:Chief vCard Evangelist
+....
+
+while this one would not:
+
+....
+  N;ALTID=1;LANGUAGE=jp:<U+5C71><U+7530>;<U+592A><U+90CE>;;;
+  N:Yamada;Taro;;;
+  (Two instances of the N property.)
+....
+
+and these three would be legal but questionable:
+
+....
+  TITLE;ALTID=1;LANGUAGE=fr:Patron
+  TITLE;ALTID=2;LANGUAGE=en:Boss
+  (Should probably have the same ALTID value.)
+....
+
+....
+  TITLE;ALTID=1;LANGUAGE=fr:Patron
+  TITLE:LANGUAGE=en:Boss
+  (Second line should probably have ALTID=1.)
+....
+
+....
+  N;ALTID=1;LANGUAGE=jp:<U+5C71><U+7530>;<U+592A><U+90CE>;;;
+  N;ALTID=1;LANGUAGE=en:Yamada;Taro;;;
+  N;ALTID=1;LANGUAGE=en:Smith;John;;;
+  (The last line should probably have ALTID=2.  But that would be
+   illegal because N has cardinality *1.)
+....
+
+The ALTID property [bcp14]#MAY# also be used in may contexts other than with
+the LANGUAGE parameter.  Here's an example with two representations
+of the same photo in different file formats:
+
+....
+  PHOTO;ALTID=1:data:image/jpeg;base64,...
+  PHOTO;ALTID=1;data:image/jp2;base64,...
+  
+  
+  
+....
+
+ABNF: ::
+[source,abnf]
+----
+        altid-param = "ALTID=" param-value
+----
+
+[[section5_5]]
+===  PID
+
+The PID parameter is used to identify a specific property among
+multiple instances.  It plays a role analogous to the UID property
+(<<section6_7_6>>) on a per-property instead of per-vCard basis.  It [bcp14]#MAY#
+appear more than once in a given property.  It [bcp14]#MUST NOT# appear on
+properties that may have only one instance per vCard.  Its value is
+either a single small positive integer or a pair of small positive
+integers separated by a dot.  Multiple values may be encoded in a
+single PID parameter by separating the values with a comma ",".  See
+<<section7>> for more details on its usage.
+
+ABNF: ::
+[source,abnf]
+----
+        pid-param = "PID=" pid-value *("," pid-value)
+        pid-value = 1*DIGIT ["." 1*DIGIT]
+----
+
+[[section5_6]]
+===  TYPE
+
+The TYPE parameter has multiple, different uses.  In general, it is a
+way of specifying class characteristics of the associated property.
+Most of the time, its value is a comma-separated subset of a
+predefined enumeration.  In this document, the following properties
+make use of this parameter: FN, NICKNAME, PHOTO, ADR, TEL, EMAIL,
+IMPP, LANG, TZ, GEO, TITLE, ROLE, LOGO, ORG, RELATED, CATEGORIES,
+NOTE, SOUND, URL, KEY, FBURL, CALADRURI, and CALURI.  The TYPE
+parameter [bcp14]#MUST NOT# be applied on other properties defined in this
+document.
+
+The "work" and "home" values act like tags.  The "work" value implies
+that the property is related to an individual's work place, while the
+"home" value implies that the property is related to an individual's
+personal life.  When neither "work" nor "home" is present, it is
+implied that the property is related to both an individual's work
+place and personal life in the case that the KIND property's value is
+"individual", or to none in other cases.
+
+ABNF: ::
+[source,abnf]
+----
+       type-param = "TYPE=" type-value *("," type-value)
+
+        type-value = "work" / "home" / type-param-tel
+                   / type-param-related / iana-token / x-name
+          ; This is further defined in individual property sections.
+----
+
+[[section5_7]]
+===  MEDIATYPE
+
+The MEDIATYPE parameter is used with properties whose value is a URI.
+Its use is [bcp14]#OPTIONAL#.  It provides a hint to the vCard consumer
+application about the media type <<RFC2046>> of the resource identified
+by the URI.  Some URI schemes do not need this parameter.  For
+example, the "data" scheme allows the media type to be explicitly
+indicated as part of the URI <<RFC2397>>.  Another scheme, "http",
+provides the media type as part of the URI resolution process, with
+the Content-Type HTTP header <<RFC2616>>.  The MEDIATYPE parameter is
+intended to be used with URI schemes that do not provide such
+functionality (e.g., "ftp" <<RFC1738>>).
+
+ABNF: ::
+[source,abnf]
+----
+  mediatype-param = "MEDIATYPE=" mediatype
+  mediatype = type-name "/" subtype-name *( ";" attribute "=" value )
+    ; "attribute" and "value" are from [RFC2045]
+    ; "type-name" and "subtype-name" are from [RFC4288]
+----
+
+<<RFC2045,format=none>> <<RFC4288,format=none>>
+
+[[section5_8]]
+===  CALSCALE
+
+The CALSCALE parameter is identical to the CALSCALE property in
+iCalendar (see <<RFC5545,section=3.7.1>>).  It is used to define the
+calendar system in which a date or date-time value is expressed.  The
+only value specified by iCalendar is "gregorian", which stands for
+the Gregorian system.  It is the default when the parameter is
+absent.  Additional values may be defined in extension documents and
+registered with IANA (see <<section10_3_4>>).  A vCard implementation
+[bcp14]#MUST# ignore properties with a CALSCALE parameter value that it does
+not understand.
+
+ABNF: ::
+[source,abnf]
+----
+        calscale-param = "CALSCALE=" calscale-value
+
+        calscale-value = "gregorian" / iana-token / x-name
+----
+
+[[section5_9]]
+===  SORT-AS
+
+The "sort-as" parameter is used to specify the string to be used for
+national-language-specific sorting.  Without this information,
+sorting algorithms could incorrectly sort this vCard within a
+sequence of sorted vCards.  When this property is present in a vCard,
+then the given strings are used for sorting the vCard.
+
+This parameter's value is a comma-separated list that [bcp14]#MUST# have as
+many or fewer elements as the corresponding property value has
+components.  This parameter's value is case-sensitive.
+
+ABNF: ::
+[source,abnf]
+----
+  sort-as-param = "SORT-AS=" sort-as-value
+
+  sort-as-value = param-value *("," param-value)
+----
+
+Examples: For the case of surname and given name sorting, the
+following examples define common sort string usage with the N
+property.
+
+....
+        FN:Rene van der Harten
+        N;SORT-AS="Harten,Rene":van der Harten;Rene,J.;Sir;R.D.O.N.
+....
+
+....
+        FN:Robert Pau Shou Chang
+        N;SORT-AS="Pau Shou Chang,Robert":Shou Chang;Robert,Pau;;
+....
+
+....
+        FN:Osamu Koura
+        N;SORT-AS="Koura,Osamu":Koura;Osamu;;
+....
+
+....
+        FN:Oscar del Pozo
+        N;SORT-AS="Pozo,Oscar":del Pozo Triscon;Oscar;;
+....
+
+....
+        FN:Chistine d'Aboville
+        N;SORT-AS="Aboville,Christine":d'Aboville;Christine;;
+....
+
+....
+        FN:H. James de Mann
+        N;SORT-AS="Mann,James":de Mann;Henry,James;;
+....
+
+If sorted by surname, the results would be:
+
+....
+        Christine d'Aboville
+        Rene van der Harten
+        Osamu Koura
+        H. James de Mann
+        Robert Pau Shou Chang
+        Oscar del Pozo
+....
+
+If sorted by given name, the results would be:
+
+....
+        Christine d'Aboville
+        H. James de Mann
+        Osamu Koura
+        Oscar del Pozo
+        Rene van der Harten
+        Robert Pau Shou Chang
+....
+
+[[section5_10]]
+===  GEO
+
+The GEO parameter can be used to indicate global positioning
+information that is specific to an address.  Its value is the same as
+that of the GEO property (see <<section6_5_2>>).
+
+ABNF: ::
+[source,abnf]
+----
+  geo-parameter = "GEO=" DQUOTE URI DQUOTE
+----
+
+[[section5_11]]
+===  TZ
+
+The TZ parameter can be used to indicate time zone information that
+is specific to an address.  Its value is the same as that of the TZ
+property.
+
+ABNF: ::
+[source,abnf]
+----
+  tz-parameter = "TZ=" (param-value / DQUOTE URI DQUOTE)
+        
+        
+        
+        
+        
+        
+----
+
+[[section6]]
+==  vCard Properties
+
+What follows is an enumeration of the standard vCard properties.
+
+[[section6_1]]
+===  General Properties
+
+[[section6_1_1]]
+====  BEGIN
+
+Purpose: :: To denote the beginning of a syntactic entity within a
+   text/vcard content-type.
+
+Value type: :: text
+
+Cardinality: :: 1
+
+Special notes: :: The content entity [bcp14]#MUST# begin with the BEGIN property
+   with a value of "VCARD".  The value is case-insensitive.
++
+The BEGIN property is used in conjunction with the END property to
+   delimit an entity containing a related set of properties within a
+   text/vcard content-type.  This construct can be used instead of
+   including multiple vCards as body parts inside of a multipart/
+   alternative MIME message.  It is provided for applications that
+   wish to define content that can contain multiple entities within
+   the same text/vcard content-type or to define content that can be
+   identifiable outside of a MIME environment.
+
+ABNF: ::
++
+[source,abnf]
+----
+  BEGIN-param = 0" "  ; no parameter allowed
+  BEGIN-value = "VCARD"
+----
+
+Example: ::
++
+....
+      BEGIN:VCARD
+....
+
+[[section6_1_2]]
+====  END
+
+Purpose: :: To denote the end of a syntactic entity within a text/vcard
+   content-type.
+
+Value type: :: text
+
+Cardinality: :: 1
+
+Special notes: :: The content entity [bcp14]#MUST# end with the END type with a
+   value of "VCARD".  The value is case-insensitive.
++
+The END property is used in conjunction with the BEGIN property to
+   delimit an entity containing a related set of properties within a
+   text/vcard content-type.  This construct can be used instead of or
+   in addition to wrapping separate sets of information inside
+   additional MIME headers.  It is provided for applications that
+   wish to define content that can contain multiple entities within
+   the same text/vcard content-type or to define content that can be
+   identifiable outside of a MIME environment.
+
+ABNF: ::
++
+[source,abnf]
+----
+  END-param = 0" "  ; no parameter allowed
+  END-value = "VCARD"
+----
+
+Example: ::
+....
+      END:VCARD
+....
+
+[[section6_1_3]]
+====  SOURCE
+
+Purpose: :: To identify the source of directory information contained
+   in the content type.
+
+Value type: :: uri
+
+Cardinality: :: *
+
+Special notes: :: The SOURCE property is used to provide the means by
+   which applications knowledgable in the given directory service
+   protocol can obtain additional or more up-to-date information from
+   the directory service.  It contains a URI as defined in <<RFC3986>>
+   and/or other information referencing the vCard to which the
+   information pertains.  When directory information is available
+   from more than one source, the sending entity can pick what it
+   considers to be the best source, or multiple SOURCE properties can
+   be included.
+
+ABNF: ::
++
+[source,abnf]
+----
+  SOURCE-param = "VALUE=uri" / pid-param / pref-param / altid-param
+               / mediatype-param / any-param
+  SOURCE-value = URI
+----
+
+Examples: ::
++
+....
+  SOURCE:ldap://ldap.example.com/cn=Babs%20Jensen,%20o=Babsco,%20c=US
+....
++
+....
+  SOURCE:http://directory.example.com/addressbooks/jdoe/
+   Jean%20Dupont.vcf
+....
+
+[[section6_1_4]]
+====  KIND
+
+Purpose: :: To specify the kind of object the vCard represents.
+
+Value type: :: A single text value.
+
+Cardinality: :: *1
+
+Special notes: :: The value may be one of the following:
++
+"individual" :: for a vCard representing a single person or entity.
+      This is the default kind of vCard.
+      
+"group" :: for a vCard representing a group of persons or entities.
+      The group's member entities can be other vCards or other types
+      of entities, such as email addresses or web sites.  A group
+      vCard will usually contain MEMBER properties to specify the
+      members of the group, but it is not required to.  A group vCard
+      without MEMBER properties can be considered an abstract
+      grouping, or one whose members are known empirically (perhaps
+      "IETF Participants" or "Republican U.S. Senators").
++
+All properties in a group vCard apply to the group as a whole,
+      and not to any particular MEMBER.  For example, an EMAIL
+      property might specify the address of a mailing list associated
+      with the group, and an IMPP property might refer to a group
+      chat room.
+"org" :: for a vCard representing an organization.  An organization
+      vCard will not (in fact, [bcp14]#MUST NOT#) contain MEMBER properties,
+      and so these are something of a cross between "individual" and
+      "group".  An organization is a single entity, but not a person.
+      It might represent a business or government, a department or
+      division within a business or government, a club, an
+      association, or the like.
++
+All properties in an organization vCard apply to the
+      organization as a whole, as is the case with a group vCard.
+      For example, an EMAIL property might specify the address of a
+      contact point for the organization.
+      
+"location" :: for a named geographical place.  A location vCard will
+      usually contain a GEO property, but it is not required to.  A
+      location vCard without a GEO property can be considered an
+      abstract location, or one whose definition is known empirically
+      (perhaps "New England" or "The Seashore").
++
+All properties in a location vCard apply to the location
+      itself, and not with any entity that might exist at that
+      location.  For example, in a vCard for an office building, an
+      ADR property might give the mailing address for the building,
+      and a TEL property might specify the telephone number of the
+      receptionist.
+An x-name. :: vCards [bcp14]#MAY# include private or experimental values for
+      KIND.  Remember that x-name values are not intended for general
+      use and are unlikely to interoperate.
+An iana-token. :: Additional values may be registered with IANA (see
+      <<section10_3_4>>).  A new value's specification document [bcp14]#MUST#
+      specify which properties make sense for that new kind of vCard
+      and which do not.
+
+Implementations [bcp14]#MUST# support the specific string values defined
+   above.  If this property is absent, "individual" [bcp14]#MUST# be assumed
+   as the default.  If this property is present but the
+   implementation does not understand its value (the value is an
+   x-name or iana-token that the implementation does not support),
+   the implementation [bcp14]#SHOULD# act in a neutral way, which usually
+   means treating the vCard as though its kind were "individual".
+   The presence of MEMBER properties [bcp14]#MAY#, however, be taken as an
+   indication that the unknown kind is an extension of "group".
+
+Clients often need to visually distinguish contacts based on what
+   they represent, and the KIND property provides a direct way for
+   them to do so.  For example, when displaying contacts in a list,
+   an icon could be displayed next to each one, using distinctive
+   icons for the different kinds; a client might use an outline of a
+   single person to represent an "individual", an outline of multiple
+   people to represent a "group", and so on.  Alternatively, or in
+   addition, a client might choose to segregate different kinds of
+   vCards to different panes, tabs, or selections in the user
+   interface.
+
+Some clients might also make functional distinctions among the
+   kinds, ignoring "location" vCards for some purposes and
+   considering only "location" vCards for others.
+
+When designing those sorts of visual and functional distinctions,
+   client implementations have to decide how to fit unsupported kinds
+   into the scheme.  What icon is used for them?  The one for
+   "individual"?  A unique one, such as an icon of a question mark?
+   Which tab do they go into?  It is beyond the scope of this
+   specification to answer these questions, but these are things
+   implementers need to consider.
+
+ABNF: ::
++
+[source,abnf]
+----
+  KIND-param = "VALUE=text" / any-param
+  KIND-value = "individual" / "group" / "org" / "location"
+             / iana-token / x-name
+----
+
+Example: ::
++
+This represents someone named Jane Doe working in the marketing
+   department of the North American division of ABC Inc.
++
+....
+      BEGIN:VCARD
+      VERSION:4.0
+      KIND:individual
+      FN:Jane Doe
+      ORG:ABC\, Inc.;North American Division;Marketing
+      END:VCARD
+....
++
+This represents the department itself, commonly known as ABC
+Marketing.
++
+....
+      BEGIN:VCARD
+      VERSION:4.0
+      KIND:org
+      FN:ABC Marketing
+      ORG:ABC\, Inc.;North American Division;Marketing
+      END:VCARD
+....
+
+[[section6_1_5]]
+====  XML
+
+Purpose: :: To include extended XML-encoded vCard data in a plain
+   vCard.
+
+Value type: :: A single text value.
+
+Cardinality: :: *
+
+Special notes: :: The content of this property is a single XML 1.0
+   <<W3C.REC-xml-20081126>> element whose namespace [bcp14]#MUST# be explicitly
+   specified using the xmlns attribute and [bcp14]#MUST NOT# be the vCard 4
+   namespace ("urn:ietf:params:xml:ns:vcard-4.0").  (This implies
+   that it cannot duplicate a standard vCard property.)  The element
+   is to be interpreted as if it was contained in a <vcard> element,
+   as defined in <<RFC6351>>.
++
+The fragment is subject to normal line folding and escaping, i.e.,
+   replace all backslashes with "\\", then replace all newlines with
+   "\n", then fold long lines.
++
+Support for this property is [bcp14]#OPTIONAL#, but implementations of this
+   specification [bcp14]#MUST# preserve instances of this property when
+   propagating vCards.
++
+See <<RFC6351>> for more information on the intended use of this
+   property.
+
+ABNF: ::
++
+[source,abnf]
+----
+  XML-param = "VALUE=text" / altid-param
+  XML-value = text
+----
+
+[[section6_2]]
+===  Identification Properties
+
+These types are used to capture information associated with the
+identification and naming of the entity associated with the vCard.
+
+[[section6_2_1]]
+====  FN
+
+Purpose: :: To specify the formatted text corresponding to the name of
+   the object the vCard represents.
+
+Value type: :: A single text value.
+
+Cardinality: :: 1*
+
+Special notes: :: This property is based on the semantics of the X.520
+   Common Name attribute <<CCITT.X520.1988>>.  The property [bcp14]#MUST# be
+   present in the vCard object.
+
+ABNF: ::
++
+[source,abnf]
+----
+  FN-param = "VALUE=text" / type-param / language-param / altid-param
+           / pid-param / pref-param / any-param
+  FN-value = text
+----
+
+Example: ::
++
+....
+      FN:Mr. John Q. Public\, Esq.
+....
+
+[[section6_2_2]]
+====  N
+
+Purpose: :: To specify the components of the name of the object the
+   vCard represents.
+
+Value type: :: A single structured text value.  Each component can have
+   multiple values.
+
+Cardinality: :: *1
+
+Special note: :: The structured property value corresponds, in
+   sequence, to the Family Names (also known as surnames), Given
+   Names, Additional Names, Honorific Prefixes, and Honorific
+   Suffixes.  The text components are separated by the SEMICOLON
+   character (U+003B).  Individual text components can include
+   multiple text values separated by the COMMA character (U+002C).
+   This property is based on the semantics of the X.520 individual
+   name attributes <<CCITT.X520.1988>>.  The property [bcp14]#SHOULD# be present
+   in the vCard object when the name of the object the vCard
+   represents follows the X.520 model.
++
+The SORT-AS parameter [bcp14]#MAY# be applied to this property.
+
+
+ABNF: ::
++
+[source,abnf]
+----
+  N-param = "VALUE=text" / sort-as-param / language-param
+          / altid-param / any-param
+  N-value = list-component 4(";" list-component)
+----
+
+Examples: ::
++
+....
+          N:Public;John;Quinlan;Mr.;Esq.
+
+          N:Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.
+....
+
+[[section6_2_3]]
+====  NICKNAME
+
+Purpose: :: To specify the text corresponding to the nickname of the
+   object the vCard represents.
+
+Value type: :: One or more text values separated by a COMMA character
+   (U+002C).
+
+Cardinality: :: *
+
+Special note: :: The nickname is the descriptive name given instead of
+   or in addition to the one belonging to the object the vCard
+   represents.  It can also be used to specify a familiar form of a
+   proper name specified by the FN or N properties.
+
+ABNF: ::
++
+[source,abnf]
+----
+  NICKNAME-param = "VALUE=text" / type-param / language-param
+                 / altid-param / pid-param / pref-param / any-param
+  NICKNAME-value = text-list
+----
+
+Examples: ::
++
+....
+          NICKNAME:Robbie
+
+          NICKNAME:Jim,Jimmie
+
+          NICKNAME;TYPE=work:Boss
+....
+
+[[section6_2_4]]
+====  PHOTO
+
+Purpose: :: To specify an image or photograph information that
+   annotates some aspect of the object the vCard represents.
+
+Value type: :: A single URI.
+
+Cardinality: :: *
+
+ABNF: ::
++
+[source,abnf]
+----
+  PHOTO-param = "VALUE=uri" / altid-param / type-param
+              / mediatype-param / pref-param / pid-param / any-param
+  PHOTO-value = URI
+----
+
+Examples: ::
++
+....
+    PHOTO:http://www.example.com/pub/photos/jqpublic.gif
+
+    PHOTO:data:image/jpeg;base64,MIICajCCAdOgAwIBAgICBEUwDQYJKoZIhv
+     AQEEBQAwdzELMAkGA1UEBhMCVVMxLDAqBgNVBAoTI05ldHNjYXBlIENvbW11bm
+     ljYXRpb25zIENvcnBvcmF0aW9uMRwwGgYDVQQLExNJbmZvcm1hdGlvbiBTeXN0
+     <...remainder of base64-encoded data...>
+....
+
+[[section6_2_5]]
+====  BDAY
+
+Purpose: :: To specify the birth date of the object the vCard
+   represents.
+
+Value type: :: The default is a single date-and-or-time value.  It can
+   also be reset to a single text value.
+
+Cardinality: ::  *1
+
+ABNF: ::
++
+[source,abnf]
+----
+  BDAY-param = BDAY-param-date / BDAY-param-text
+  BDAY-value = date-and-or-time / text
+    ; Value and parameter MUST match.
+
+  BDAY-param-date = "VALUE=date-and-or-time"
+  BDAY-param-text = "VALUE=text" / language-param
+
+  BDAY-param =/ altid-param / calscale-param / any-param
+    ; calscale-param can only be present when BDAY-value is
+    ; date-and-or-time and actually contains a date or date-time.
+----
+
+Examples: ::
++
+....
+          BDAY:19960415
+          BDAY:--0415
+          BDAY;19531015T231000Z
+          BDAY;VALUE=text:circa 1800
+....
+
+[[section6_2_6]]
+====  ANNIVERSARY
+
+Purpose: :: The date of marriage, or equivalent, of the object the
+   vCard represents.
+
+Value type: :: The default is a single date-and-or-time value.  It can
+   also be reset to a single text value.
+
+Cardinality: :: *1
+
+ABNF: ::
++
+[source,abnf]
+----
+  ANNIVERSARY-param = "VALUE=" ("date-and-or-time" / "text")
+  ANNIVERSARY-value = date-and-or-time / text
+    ; Value and parameter MUST match.
+
+  ANNIVERSARY-param =/ altid-param / calscale-param / any-param
+    ; calscale-param can only be present when ANNIVERSARY-value is
+    ; date-and-or-time and actually contains a date or date-time.
+----
+
+Examples: ::
++
+....
+          ANNIVERSARY:19960415
+....
+
+
+[[section6_2_7]]
+====  GENDER
+
+Purpose: :: To specify the components of the sex and gender identity of
+   the object the vCard represents.
+
+Value type: :: A single structured value with two components.  Each
+   component has a single text value.
+
+Cardinality: :: *1
+
+Special notes: :: The components correspond, in sequence, to the sex
+   (biological), and gender identity.  Each component is optional.
+
+Sex component: ::: A single letter.  M stands for "male", F stands
+      for "female", O stands for "other", N stands for "none or not
+      applicable", U stands for "unknown".
+
+Gender identity component: ::: Free-form text.
+
+ABNF: ::
++
+[source,abnf]
+----
+                GENDER-param = "VALUE=text" / any-param
+                GENDER-value = sex [";" text]
+
+                sex = "" / "M" / "F" / "O" / "N" / "U"
+----
+
+Examples: ::
++
+....
+  GENDER:M
+  GENDER:F
+  GENDER:M;Fellow
+  GENDER:F;grrrl
+  GENDER:O;intersex
+  GENDER:;it's complicated
+....
+
+[[section6_3]]
+=== Delivery Addressing Properties
+
+These types are concerned with information related to the delivery
+addressing or label for the vCard object.
+
+[[section6_3_1]]
+====  ADR
+
+Purpose: :: To specify the components of the delivery address for the
+   vCard object.
+
+Value type: :: A single structured text value, separated by the
+   SEMICOLON character (U+003B).
+
+Cardinality: :: *
+
+Special notes: :: The structured type value consists of a sequence of
+   address components.  The component values [bcp14]#MUST# be specified in
+   their corresponding position.  The structured type value
+   corresponds, in sequence, to
++
+[empty]
+* the post office box;
+* the extended address (e.g., apartment or suite number);
+* the street address;
+* the locality (e.g., city);
+* the region (e.g., state or province);
+* the postal code;
+* the country name (full name in the language specified in
+      <<section5_1>>).
+
+When a component value is missing, the associated component
+   separator [bcp14]#MUST# still be specified.
+
+Experience with vCard 3 has shown that the first two components
+   (post office box and extended address) are plagued with many
+   interoperability issues.  To ensure maximal interoperability,
+   their values [bcp14]#SHOULD# be empty.
+
+The text components are separated by the SEMICOLON character
+   (U+003B).  Where it makes semantic sense, individual text
+   components can include multiple text values (e.g., a "street"
+   component with multiple lines) separated by the COMMA character
+   (U+002C).
+
+The property can include the "PREF" parameter to indicate the
+   preferred delivery address when more than one address is
+   specified.
+
+The GEO and TZ parameters [bcp14]#MAY# be used with this property.
+
+The property can also include a "LABEL" parameter to present a
+   delivery address label for the address.  Its value is a plain-text
+   string representing the formatted address.  Newlines are encoded
+   as \n, as they are for property values.
+
+ABNF: ::
++
+[source,abnf]
+----
+  label-param = "LABEL=" param-value
+
+  ADR-param = "VALUE=text" / label-param / language-param
+            / geo-parameter / tz-parameter / altid-param / pid-param
+            / pref-param / type-param / any-param
+
+  ADR-value = ADR-component-pobox ";" ADR-component-ext ";"
+              ADR-component-street ";" ADR-component-locality ";"
+              ADR-component-region ";" ADR-component-code ";"
+              ADR-component-country
+  ADR-component-pobox    = list-component
+  ADR-component-ext      = list-component
+  ADR-component-street   = list-component
+  ADR-component-locality = list-component
+  ADR-component-region   = list-component
+  ADR-component-code     = list-component
+  ADR-component-country  = list-component
+----
+
+Example: :: In this example, the post office box and the extended
+address are absent.
++
+....
+  ADR;GEO="geo:12.3457,78.910";LABEL="Mr. John Q. Public, Esq.\n
+   Mail Drop: TNE QB\n123 Main Street\nAny Town, CA  91921-1234\n
+   U.S.A.":;;123 Main Street;Any Town;CA;91921-1234;U.S.A.
+....
+
+[[section6_4]]
+===  Communications Properties
+
+These properties describe information about how to communicate with
+the object the vCard represents.
+
+[[section6_4_1]]
+====  TEL
+
+Purpose: :: To specify the telephone number for telephony communication
+   with the object the vCard represents.
+
+Value type: :: By default, it is a single free-form text value (for
+   backward compatibility with vCard 3), but it [bcp14]#SHOULD# be reset to a
+   URI value.  It is expected that the URI scheme will be "tel", as
+   specified in <<RFC3966>>, but other schemes [bcp14]#MAY# be used.
+
+Cardinality: :: *
+
+Special notes: :: This property is based on the X.520 Telephone Number
+   attribute <<CCITT.X520.1988>>.
++
+The property can include the "PREF" parameter to indicate a
+   preferred-use telephone number.
++
+The property can include the parameter "TYPE" to specify intended
+   use for the telephone number.  The predefined values for the TYPE
+   parameter are:
+
+[cols="2"]
+|===
+| Value     | Description                                           
+
+| text      | Indicates that the telephone number supports text messages (SMS).                                       
+| voice     | Indicates a voice telephone number.                   
+| fax       | Indicates a facsimile telephone number.               
+| cell      | Indicates a cellular or mobile telephone number.      
+| video     | Indicates a video conferencing telephone number.      
+| pager     | Indicates a paging device telephone number.           
+| textphone 
+| Indicates a telecommunication device for people with  hearing or speech difficulties.                       
+|===
+
+The default type is "voice".  These type parameter values can be
+   specified as a parameter list (e.g., TYPE=text;TYPE=voice) or as a
+   value list (e.g., TYPE="text,voice").  The default can be
+   overridden to another set of values by specifying one or more
+   alternate values.  For example, the default TYPE of "voice" can be
+   reset to a VOICE and FAX telephone number by the value list
+   TYPE="voice,fax".
+
+If this property's value is a URI that can also be used for
+   instant messaging, the IMPP (<<section6_4_3>>) property [bcp14]#SHOULD# be
+   used in addition to this property.
+
+ABNF: ::
++
+[source,abnf]
+----
+  TEL-param = TEL-text-param / TEL-uri-param
+  TEL-value = TEL-text-value / TEL-uri-value
+    ; Value and parameter MUST match.
+
+  TEL-text-param = "VALUE=text"
+  TEL-text-value = text
+
+  TEL-uri-param = "VALUE=uri" / mediatype-param
+  TEL-uri-value = URI
+
+  TEL-param =/ type-param / pid-param / pref-param / altid-param
+             / any-param
+
+  type-param-tel = "text" / "voice" / "fax" / "cell" / "video"
+                 / "pager" / "textphone" / iana-token / x-name
+    ; type-param-tel MUST NOT be used with a property other than TEL.
+
+----
+
+Example: ::
++
+....
+  TEL;VALUE=uri;PREF=1;TYPE="voice,home":tel:+1-555-555-5555;ext=5555
+  TEL;VALUE=uri;TYPE=home:tel:+33-01-23-45-67
+....
+
+[[section6_4_2]]
+====  EMAIL
+
+Purpose: :: To specify the electronic mail address for communication
+   with the object the vCard represents.
+
+Value type: :: A single text value.
+
+Cardinality: :: *
+
+Special notes: :: The property can include tye "PREF" parameter to
+   indicate a preferred-use email address when more than one is
+   specified.
++
+Even though the value is free-form UTF-8 text, it is likely to be
+   interpreted by a Mail User Agent (MUA) as an "addr-spec", as
+   defined in <<RFC5322,section=3.4.1>>.  Readers should also be aware
+   of the current work toward internationalized email addresses
+   <<RFC5335bis>>.
+
+ABNF: ::
++
+[source,abnf]
+----
+  EMAIL-param = "VALUE=text" / pid-param / pref-param / type-param
+              / altid-param / any-param
+  EMAIL-value = text
+----
+
+Example: ::
++
+....
+        EMAIL;TYPE=work:jqpublic@xyz.example.com
+
+        EMAIL;PREF=1:jane_doe@example.com
+....
+
+[[section6_4_3]]
+====  IMPP
+
+Purpose: :: To specify the URI for instant messaging and presence
+   protocol communications with the object the vCard represents.
+
+Value type: :: A single URI.
+
+Cardinality: :: *
+
+Special notes: :: The property may include the "PREF" parameter to
+   indicate that this is a preferred address and has the same
+   semantics as the "PREF" parameter in a TEL property.
++
+If this property's value is a URI that can be used for voice
+and/or video, the TEL property (<<section6_4_1>>) [bcp14]#SHOULD# be used in
+addition to this property.
++
+This property is adapted from <<RFC4770>>, which is made obsolete by
+   this document.
+
+ABNF: ::
++
+[source,abnf]
+----
+  IMPP-param = "VALUE=uri" / pid-param / pref-param / type-param
+             / mediatype-param / altid-param / any-param
+  IMPP-value = URI
+----
+
+Example: ::
++
+....
+    IMPP;PREF=1:xmpp:alice@example.com
+....
+
+[[section6_4_4]]
+====  LANG
+
+Purpose: :: To specify the language(s) that may be used for contacting
+   the entity associated with the vCard.
+
+Value type: :: A single language-tag value.
+
+Cardinality: :: *
+
+ABNF: ::
++
+[source,abnf]
+----
+  LANG-param = "VALUE=language-tag" / pid-param / pref-param
+             / altid-param / type-param / any-param
+  LANG-value = Language-Tag
+----
+
+Example: ::
++
+....
+    LANG;TYPE=work;PREF=1:en
+    LANG;TYPE=work;PREF=2:fr
+    LANG;TYPE=home:fr
+....
+
+[[section6_5]]
+===  Geographical Properties
+
+These properties are concerned with information associated with
+geographical positions or regions associated with the object the
+vCard represents.
+
+[[section6_5_1]]
+====  TZ
+
+Purpose: :: To specify information related to the time zone of the
+   object the vCard represents.
+
+Value type: :: The default is a single text value.  It can also be
+   reset to a single URI or utc-offset value.
+
+Cardinality: :: *
+
+Special notes: :: It is expected that names from the public-domain
+   Olson database <<TZ-DB>> will be used, but this is not a
+   restriction.  See also <<IANA-TZ>>.
++
+Efforts are currently being directed at creating a standard URI
+   scheme for expressing time zone information.  Usage of such a
+   scheme would ensure a high level of interoperability between
+   implementations that support it.
++
+Note that utc-offset values [bcp14]#SHOULD NOT# be used because the UTC
+   offset varies with time -- not just because of the usual daylight
+   saving time shifts that occur in may regions, but often entire
+   regions will "re-base" their overall offset.  The actual offset
+   may be +/- 1 hour (or perhaps a little more) than the one given.
+
+ABNF: ::
++
+[source,abnf]
+----
+  TZ-param = "VALUE=" ("text" / "uri" / "utc-offset")
+  TZ-value = text / URI / utc-offset
+    ; Value and parameter MUST match.
+
+  TZ-param =/ altid-param / pid-param / pref-param / type-param
+            / mediatype-param / any-param
+----
+
+Examples: ::
++
+....
+  TZ:Raleigh/North America
+
+  TZ;VALUE=utc-offset:-0500
+    ; Note: utc-offset format is NOT RECOMMENDED.
+....
+
+[[section6_5_2]]
+====  GEO
+
+Purpose: :: To specify information related to the global positioning of
+   the object the vCard represents.
+
+Value type: :: A single URI.
+
+Cardinality: ::  *
+
+Special notes: :: The "geo" URI scheme <<RFC5870>> is particularly well
+   suited for this property, but other schemes [bcp14]#MAY# be used.
+
+
+ABNF: ::
++
+[source,abnf]
+----
+  GEO-param = "VALUE=uri" / pid-param / pref-param / type-param
+            / mediatype-param / altid-param / any-param
+  GEO-value = URI
+----
+
+Example: ::
++
+....
+        GEO:geo:37.386013,-122.082932
+....
+
+[[section6_6]]
+===  Organizational Properties
+
+These properties are concerned with information associated with
+characteristics of the organization or organizational units of the
+object that the vCard represents.
+
+[[section6_6_1]]
+====  TITLE
+
+Purpose: :: To specify the position or job of the object the vCard
+   represents.
+
+Value type: :: A single text value.
+
+Cardinality:  *
+
+Special notes: :: This property is based on the X.520 Title attribute
+   <<CCITT.X520.1988>>.
+
+ABNF: ::
++
+[source,abnf]
+----
+  TITLE-param = "VALUE=text" / language-param / pid-param
+              / pref-param / altid-param / type-param / any-param
+  TITLE-value = text
+----
+
+Example: ::
++
+....
+        TITLE:Research Scientist
+....
+
+[[section6_6_2]]
+====  ROLE
+
+Purpose: :: To specify the function or part played in a particular
+   situation by the object the vCard represents.
+
+Value type: :: A single text value.
+
+Cardinality: :: *
+
+Special notes:  This property is based on the X.520 Business Category
+   explanatory attribute <<CCITT.X520.1988>>.  This property is
+   included as an organizational type to avoid confusion with the
+   semantics of the TITLE property and incorrect usage of that
+   property when the semantics of this property is intended.
+
+ABNF: ::
++
+[source,abnf]
+----
+  ROLE-param = "VALUE=text" / language-param / pid-param / pref-param
+             / type-param / altid-param / any-param
+  ROLE-value = text
+----
+
+Example: ::
++
+....
+        ROLE:Project Leader
+....
+
+[[section6_6_3]]
+====  LOGO
+
+Purpose: :: To specify a graphic image of a logo associated with the
+   object the vCard represents.
+
+Value type: :: A single URI.
+
+Cardinality: :: *
+
+ABNF: ::
++
+[source,abnf]
+----
+  LOGO-param = "VALUE=uri" / language-param / pid-param / pref-param
+             / type-param / mediatype-param / altid-param / any-param
+  LOGO-value = URI
+----
+
+Examples: ::
++
+....
+  LOGO:http://www.example.com/pub/logos/abccorp.jpg
+
+  LOGO:data:image/jpeg;base64,MIICajCCAdOgAwIBAgICBEUwDQYJKoZIhvc
+   AQEEBQAwdzELMAkGA1UEBhMCVVMxLDAqBgNVBAoTI05ldHNjYXBlIENvbW11bm
+   ljYXRpb25zIENvcnBvcmF0aW9uMRwwGgYDVQQLExNJbmZvcm1hdGlvbiBTeXN0
+   <...the remainder of base64-encoded data...>
+....
+
+[[section6_6_4]]
+====  ORG
+
+Purpose: :: To specify the organizational name and units associated
+   with the vCard.
+
+Value type: :: A single structured text value consisting of components
+   separated by the SEMICOLON character (U+003B).
+
+Cardinality: :: *
+
+Special notes: ::  The property is based on the X.520 Organization Name
+   and Organization Unit attributes <<CCITT.X520.1988>>.  The property
+   value is a structured type consisting of the organization name,
+   followed by zero or more levels of organizational unit names.
++
+The SORT-AS parameter [bcp14]#MAY# be applied to this property.
+
+ABNF: ::
++
+[source,abnf]
+----
+  ORG-param = "VALUE=text" / sort-as-param / language-param
+            / pid-param / pref-param / altid-param / type-param
+            / any-param
+  ORG-value = component *(";" component)
+----
+
+Example: :: A property value consisting of an organizational name,
+organizational unit #1 name, and organizational unit #2 name.
++
+....
+        ORG:ABC\, Inc.;North American Division;Marketing
+....
+
+[[section6_6_5]]
+====  MEMBER
+
+Purpose: :: To include a member in the group this vCard represents.
+
+Value type: :: A single URI.  It [bcp14]#MAY# refer to something other than a
+   vCard object.  For example, an email distribution list could
+   employ the "mailto" URI scheme <<RFC6068>> for efficiency.
+
+Cardinality: :: *
+
+Special notes: :: This property [bcp14]#MUST NOT# be present unless the value of
+   the KIND property is "group".
+
+ABNF: ::
++
+[source,abnf]
+----
+  MEMBER-param = "VALUE=uri" / pid-param / pref-param / altid-param
+               / mediatype-param / any-param
+  MEMBER-value = URI
+----
+
+Examples: ::
++
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  KIND:group
+  FN:The Doe family
+  MEMBER:urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af
+  MEMBER:urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519
+  END:VCARD
+  BEGIN:VCARD
+  VERSION:4.0
+  FN:John Doe
+  UID:urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af
+  END:VCARD
+  BEGIN:VCARD
+  VERSION:4.0
+  FN:Jane Doe
+  UID:urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519
+  END:VCARD
+
+  BEGIN:VCARD
+  VERSION:4.0
+  KIND:group
+  FN:Funky distribution list
+  MEMBER:mailto:subscriber1@example.com
+  MEMBER:xmpp:subscriber2@example.com
+  MEMBER:sip:subscriber3@example.com
+  MEMBER:tel:+1-418-555-5555
+  END:VCARD
+....
+
+[[section6_6_6]]
+====  RELATED
+
+Purpose: :: To specify a relationship between another entity and the
+   entity represented by this vCard.
+
+Value type: :: A single URI.  It can also be reset to a single text
+   value.  The text value can be used to specify textual information.
+
+Cardinality: :: *
+
+Special notes: :: The TYPE parameter [bcp14]#MAY# be used to characterize the
+   related entity.  It contains a comma-separated list of values that
+   are registered with IANA as described in <<section10_2>>.  The
+   registry is pre-populated with the values defined in <<xfn>>.  This
+   document also specifies two additional values:
+
+agent: ::: an entity who may sometimes act on behalf of the entity
+      associated with the vCard.
+
+emergency: ::: indicates an emergency contact
+
++
+ABNF: ::
++
+[source,abnf]
+----
+  RELATED-param = RELATED-param-uri / RELATED-param-text
+  RELATED-value = URI / text
+    ; Parameter and value MUST match.
+
+  RELATED-param-uri = "VALUE=uri" / mediatype-param
+  RELATED-param-text = "VALUE=text" / language-param
+
+  RELATED-param =/ pid-param / pref-param / altid-param / type-param
+                 / any-param
+
+  type-param-related = related-type-value *("," related-type-value)
+    ; type-param-related MUST NOT be used with a property other than
+    ; RELATED.
+
+  related-type-value = "contact" / "acquaintance" / "friend" / "met"
+                     / "co-worker" / "colleague" / "co-resident"
+                     / "neighbor" / "child" / "parent"
+                     / "sibling" / "spouse" / "kin" / "muse"
+                     / "crush" / "date" / "sweetheart" / "me"
+                     / "agent" / "emergency"
+----
+
+Examples: ::
++
+....
+RELATED;TYPE=friend:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+RELATED;TYPE=contact:http://example.com/directory/jdoe.vcf
+RELATED;TYPE=co-worker;VALUE=text:Please contact my assistant Jane
+ Doe for any inquiries.
+....
+
+[[section6_7]]
+===  Explanatory Properties
+
+These properties are concerned with additional explanations, such as
+that related to informational notes or revisions specific to the
+vCard.
+
+[[section6_7_1]]
+====  CATEGORIES
+
+Purpose: :: To specify application category information about the
+   vCard, also known as "tags".
+
+Value type: :: One or more text values separated by a COMMA character
+   (U+002C).
+
+Cardinality: :: *
+
+ABNF: ::
++
+[source,abnf]
+----
+  CATEGORIES-param = "VALUE=text" / pid-param / pref-param
+                   / type-param / altid-param / any-param
+  CATEGORIES-value = text-list
+----
+
+Example: ::
++
+....
+        CATEGORIES:TRAVEL AGENT
+
+        CATEGORIES:INTERNET,IETF,INDUSTRY,INFORMATION TECHNOLOGY
+....
+
+[[section6_7_2]]
+====  NOTE
+
+Purpose: :: To specify supplemental information or a comment that is
+   associated with the vCard.
+
+Value type: :: A single text value.
+
+Cardinality: :: *
+
+Special notes:  The property is based on the X.520 Description
+   attribute <<CCITT.X520.1988>>.
+
+ABNF: ::
++
+[source,abnf]
+----
+  NOTE-param = "VALUE=text" / language-param / pid-param / pref-param
+             / type-param / altid-param / any-param
+  NOTE-value = text
+----
+
+Example: ::
++
+....
+        NOTE:This fax number is operational 0800 to 1715
+          EST\, Mon-Fri.
+....
+
+[[section6_7_3]]
+====  PRODID
+
+Purpose: :: To specify the identifier for the product that created the
+   vCard object.
+
+Type value: :: A single text value.
+
+Cardinality: :: *1
+
+Special notes: :: Implementations [bcp14]#SHOULD# use a method such as that
+   specified for Formal Public Identifiers in <<ISO9070>> or for
+   Universal Resource Names in <<RFC3406>> to ensure that the text
+   value is unique.
+
+ABNF: ::
++
+[source,abnf]
+----
+  PRODID-param = "VALUE=text" / any-param
+  PRODID-value = text
+----
+
+Example: ::
++
+....
+        PRODID:-//ONLINE DIRECTORY//NONSGML Version 1//EN
+....
+
+[[section6_7_4]]
+====  REV
+
+Purpose: :: To specify revision information about the current vCard.
+
+Value type: :: A single timestamp value.
+
+Cardinality: :: *1
+
+Special notes: :: The value distinguishes the current revision of the
+   information in this vCard for other renditions of the information.
+
+ABNF: ::
++
+[source,abnf]
+----
+  REV-param = "VALUE=timestamp" / any-param
+  REV-value = timestamp
+----
+
+Example: ::
++
+....
+        REV:19951031T222710Z
+....
+
+[[section6_7_5]]
+====  SOUND
+
+Purpose: :: To specify a digital sound content information that
+   annotates some aspect of the vCard.  This property is often used
+   to specify the proper pronunciation of the name property value of
+   the vCard.
+
+Value type: :: A single URI.
+
+Cardinality: ::  *
+
+ABNF: ::
++
+[source,abnf]
+----
+  SOUND-param = "VALUE=uri" / language-param / pid-param / pref-param
+              / type-param / mediatype-param / altid-param
+              / any-param
+  SOUND-value = URI
+----
+
+Example: ::
++
+....
+  SOUND:CID:JOHNQPUBLIC.part8.19960229T080000.xyzMail@example.com
+
+  SOUND:data:audio/basic;base64,MIICajCCAdOgAwIBAgICBEUwDQYJKoZIh
+   AQEEBQAwdzELMAkGA1UEBhMCVVMxLDAqBgNVBAoTI05ldHNjYXBlIENvbW11bm
+   ljYXRpb25zIENvcnBvcmF0aW9uMRwwGgYDVQQLExNJbmZvcm1hdGlvbiBTeXN0
+   <...the remainder of base64-encoded data...>
+....
+
+[[section6_7_6]]
+====  UID
+
+Purpose: :: To specify a value that represents a globally unique
+   identifier corresponding to the entity associated with the vCard.
+
+Value type: :: A single URI value.  It [bcp14]#MAY# also be reset to free-form
+   text.
+
+Cardinality: :: *1
+
+Special notes: :: This property is used to uniquely identify the object
+   that the vCard represents.  The "uuid" URN namespace defined in
+   <<RFC4122>> is particularly well suited to this task, but other URI
+   schemes [bcp14]#MAY# be used.  Free-form text [bcp14]#MAY# also be used.
+
+ABNF: ::
++
+[source,abnf]
+----
+  UID-param = UID-uri-param / UID-text-param
+  UID-value = UID-uri-value / UID-text-value
+    ; Value and parameter MUST match.
+
+  UID-uri-param = "VALUE=uri"
+  UID-uri-value = URI
+
+  UID-text-param = "VALUE=text"
+  UID-text-value = text
+
+  UID-param =/ any-param
+----
+
+Example: ::
++
+....
+        UID:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+....
+
+[[section6_7_7]]
+====  CLIENTPIDMAP
+
+Purpose: :: To give a global meaning to a local PID source identifier.
+
+Value type: :: A semicolon-separated pair of values.  The first field
+   is a small integer corresponding to the second field of a PID
+   parameter instance.  The second field is a URI.  The "uuid" URN
+   namespace defined in <<RFC4122>> is particularly well suited to this
+   task, but other URI schemes [bcp14]#MAY# be used.
+
+Cardinality: :: *
+
+Special notes: :: PID source identifiers (the source identifier is the
+   second field in a PID parameter instance) are small integers that
+   only have significance within the scope of a single vCard
+   instance.  Each distinct source identifier present in a vCard [bcp14]#MUST#
+   have an associated CLIENTPIDMAP.  See <<section7>> for more details
+   on the usage of CLIENTPIDMAP.
++
+PID source identifiers [bcp14]#MUST# be strictly positive.  Zero is not
+   allowed.
++
+As a special exception, the PID parameter [bcp14]#MUST NOT# be applied to
+   this property.
+
+ABNF: ::
++
+[source,abnf]
+----
+  CLIENTPIDMAP-param = any-param
+  CLIENTPIDMAP-value = 1*DIGIT ";" URI
+----
+
+Example: ::
++
+....
+  TEL;PID=3.1,4.2;VALUE=uri:tel:+1-555-555-5555
+  EMAIL;PID=4.1,5.2:jdoe@example.com
+  CLIENTPIDMAP:1;urn:uuid:3df403f4-5924-4bb7-b077-3c711d9eb34b
+  CLIENTPIDMAP:2;urn:uuid:d89c9c7a-2e1b-4832-82de-7e992d95faa5
+....
+
+[[section6_7_8]]
+====  URL
+
+Purpose: :: To specify a uniform resource locator associated with the
+   object to which the vCard refers.  Examples for individuals
+   include personal web sites, blogs, and social networking site
+   identifiers.
+
+Cardinality: :: *
+
+Value type: :: A single uri value.
+
+ABNF: ::
++
+[source,abnf]
+----
+  URL-param = "VALUE=uri" / pid-param / pref-param / type-param
+            / mediatype-param / altid-param / any-param
+  URL-value = URI
+----
+
+Example: ::
++
+....
+        URL:http://example.org/restaurant.french/~chezchic.html
+....
+
+[[section6_7_9]]
+====  VERSION
+
+Purpose: :: To specify the version of the vCard specification used to
+   format this vCard.
+
+Value type: :: A single text value.
+
+Cardinality: :: 1
+
+Special notes: ::  This property [bcp14]#MUST# be present in the vCard object,
+   and it must appear immediately after BEGIN:VCARD.  The value [bcp14]#MUST#
+   be "4.0" if the vCard corresponds to this specification.  Note
+   that earlier versions of vCard allowed this property to be placed
+   anywhere in the vCard object, or even to be absent.
+
+ABNF: ::
++
+[source,abnf]
+----
+  VERSION-param = "VALUE=text" / any-param
+  VERSION-value = "4.0"
+----
+
+Example: ::
++
+....
+        VERSION:4.0
+....
+
+[[section6_8]]
+===  Security Properties
+
+These properties are concerned with the security of communication
+pathways or access to the vCard.
+
+[[section6_8_1]]
+====  KEY
+
+Purpose: :: To specify a public key or authentication certificate
+   associated with the object that the vCard represents.
+
+Value type: :: A single URI.  It can also be reset to a text value.
+
+Cardinality: :: *
+
+ABNF: ::
++
+[source,abnf]
+----
+  KEY-param = KEY-uri-param / KEY-text-param
+  KEY-value = KEY-uri-value / KEY-text-value
+    ; Value and parameter MUST match.
+
+  KEY-uri-param = "VALUE=uri" / mediatype-param
+  KEY-uri-value = URI
+
+  KEY-text-param = "VALUE=text"
+  KEY-text-value = text
+
+  KEY-param =/ altid-param / pid-param / pref-param / type-param
+             / any-param
+----
+
+Examples: ::
++
+....
+  KEY:http://www.example.com/keys/jdoe.cer
+
+  KEY;MEDIATYPE=application/pgp-keys:ftp://example.com/keys/jdoe
+
+  KEY:data:application/pgp-keys;base64,MIICajCCAdOgAwIBAgICBE
+   UwDQYJKoZIhvcNAQEEBQAwdzELMAkGA1UEBhMCVVMxLDAqBgNVBAoTI05l
+   <... remainder of base64-encoded data ...>
+....
+
+[[section6_9]]
+===  Calendar Properties
+
+These properties are further specified in <<RFC2739>>.
+
+[[secton6_9_1]]
+====  FBURL
+
+Purpose: :: To specify the URI for the busy time associated with the
+   object that the vCard represents.
+
+Value type: :: A single URI value.
+
+Cardinality: :: *
+
+Special notes: :: Where multiple FBURL properties are specified, the
+   default FBURL property is indicated with the PREF parameter.  The
+   FTP <<RFC1738>> or HTTP <<RFC2616>> type of URI points to an iCalendar
+   <<RFC5545>> object associated with a snapshot of the next few weeks
+   or months of busy time data.  If the iCalendar object is
+   represented as a file or document, its file extension should be
+   ".ifb".
+
+ABNF: ::
++
+[source,abnf]
+----
+  FBURL-param = "VALUE=uri" / pid-param / pref-param / type-param
+              / mediatype-param / altid-param / any-param
+  FBURL-value = URI
+----
+
+Examples: ::
++
+....
+  FBURL;PREF=1:http://www.example.com/busy/janedoe
+  FBURL;MEDIATYPE=text/calendar:ftp://example.com/busy/project-a.ifb
+....
+
+[[section6_9_2]]
+====  CALADRURI
+
+Purpose: :: To specify the calendar user address <<RFC5545>> to which a
+   scheduling request <<RFC5546>> should be sent for the object
+   represented by the vCard.
+
+Value type: :: A single URI value.
+
+Cardinality: :: *
+
+Special notes: ::  Where multiple CALADRURI properties are specified,
+   the default CALADRURI property is indicated with the PREF
+   parameter.
+
+ABNF: ::
++
+[source,abnf]
+----
+  CALADRURI-param = "VALUE=uri" / pid-param / pref-param / type-param
+                  / mediatype-param / altid-param / any-param
+  CALADRURI-value = URI
+----
+
+Example: ::
++
+....
+  CALADRURI;PREF=1:mailto:janedoe@example.com
+  CALADRURI:http://example.com/calendar/jdoe
+....
+
+[[section6_9_3]]
+====  CALURI
+
+Purpose: :: To specify the URI for a calendar associated with the
+   object represented by the vCard.
+
+Value type: :: A single URI value.
+
+Cardinality: :: *
+
+Special notes: :: Where multiple CALURI properties are specified, the
+   default CALURI property is indicated with the PREF parameter.  The
+   property should contain a URI pointing to an iCalendar <<RFC5545>>
+   object associated with a snapshot of the user's calendar store.
+   If the iCalendar object is represented as a file or document, its
+   file extension should be ".ics".
+
+ABNF: ::
++
+[source,abnf]
+----
+  CALURI-param = "VALUE=uri" / pid-param / pref-param / type-param
+               / mediatype-param / altid-param / any-param
+  CALURI-value = URI
+----
+
+Examples: ::
++
+....
+  CALURI;PREF=1:http://cal.example.com/calA
+  CALURI;MEDIATYPE=text/calendar:ftp://ftp.example.com/calA.ics
+....
+
+[[section6_10]]
+===  Extended Properties and Parameters
+
+The properties and parameters defined by this document can be
+extended.  Non-standard, private properties and parameters with a
+name starting with "X-" may be defined bilaterally between two
+cooperating agents without outside registration or standardization.
+
+[[section7]]
+==  Synchronization
+
+vCard data often needs to be synchronized between devices.  In this
+context, synchronization is defined as the intelligent merging of two
+representations of the same object. vCard 4.0 includes mechanisms to
+aid this process.
+
+[[section7_1]]
+===  Mechanisms
+
+Two mechanisms are available: the UID property is used to match
+multiple instances of the same vCard, while the PID parameter is used
+to match multiple instances of the same property.
+
+The term "matching" is used here to mean recognizing that two
+instances are in fact representations of the same object.  For
+example, a single vCard that is shared with someone results in two
+vCard instances.  After they have evolved separately, they still
+represent the same object, and therefore may be matched by a
+synchronization engine.
+
+[[section7_1_1]]
+====  Matching vCard Instances
+
+vCard instances for which the UID properties (<<section6_7_6>>) are
+equivalent [bcp14]#MUST# be matched.  Equivalence is determined as specified
+in <<RFC3986,section=6>>.
+
+In all other cases, vCard instances [bcp14]#MAY# be matched at the discretion
+of the synchronization engine.
+
+[[section7_1_2]]
+====  Matching Property Instances
+
+Property instances belonging to unmatched vCards [bcp14]#MUST NOT# be matched.
+
+Property instances whose name (e.g., EMAIL, TEL, etc.) is not the
+same [bcp14]#MUST NOT# be matched.
+
+Property instances whose name is CLIENTPIDMAP are handled separately
+and [bcp14]#MUST NOT# be matched.  The synchronization [bcp14]#MUST# ensure that there
+is consistency of CLIENTPIDMAPs among matched vCard instances.
+
+Property instances belonging to matched vCards, whose name is the
+same, and whose maximum cardinality is 1, [bcp14]#MUST# be matched.
+
+Property instances belonging to matched vCards, whose name is the
+same, and whose PID parameters match, [bcp14]#MUST# be matched.  See
+<<section7_1_3>> for details on PID matching.
+
+In all other cases, property instances [bcp14]#MAY# be matched at the
+discretion of the synchronization engine.
+
+[[section7_1_3]]
+====  PID Matching
+
+Two PID values for which the first fields are equivalent represent
+the same local value.
+
+Two PID values representing the same local value and for which the
+second fields point to CLIENTPIDMAP properties whose second field
+URIs are equivalent (as specified in <<RFC3986,section=6>>) also
+represent the same global value.
+
+PID parameters for which at least one pair of their values represent
+the same global value [bcp14]#MUST# be matched.
+
+In all other cases, PID parameters [bcp14]#MAY# be matched at the discretion
+of the synchronization engine.
+
+For example, PID value "5.1", in the first vCard below, and PID value
+"5.2", in the second vCard below, represent the same global value.
+
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  EMAIL;PID=4.2,5.1:jdoe@example.com
+  CLIENTPIDMAP:1;urn:uuid:3eef374e-7179-4196-a914-27358c3e6527
+  CLIENTPIDMAP:2;urn:uuid:42bcd5a7-1699-4514-87b4-056edf68e9cc
+  END:VCARD
+....
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  EMAIL;PID=5.1,5.2:john@example.com
+  CLIENTPIDMAP:1;urn:uuid:0c75c629-6a8d-4d5e-a07f-1bb35846854d
+  CLIENTPIDMAP:2;urn:uuid:3eef374e-7179-4196-a914-27358c3e6527
+  END:VCARD
+....
+
+[[section7_2]]
+===  Example
+
+[[section7_2_1]]
+====  Creation
+
+The following simple vCard is first created on a given device.
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN;PID=1.1:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  END:VCARD
+....
+
+This new vCard is assigned the UID
+"urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1" by the creating
+device.  The FN and EMAIL properties are assigned the same local
+value of 1, and this value is given global context by associating it
+with "urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556", which
+represents the creating device.  We are at liberty to reuse the same
+local value since instances of different properties will never be
+matched.  The N property has no PID because it is forbidden by its
+maximum cardinality of 1.
+
+[[section7_2_2]]
+====  Initial Sharing
+
+This vCard is shared with a second device.  Upon inspecting the UID
+property, the second device understands that this is a new vCard
+(i.e., unmatched) and thus the synchronization results in a simple
+copy.
+
+[[section7_2_3]]
+====  Adding and Sharing a Property
+
+A new phone number is created on the first device, then the vCard is
+shared with the second device.  This is what the second device
+receives:
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN;PID=1.1:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  TEL;PID=1.1;VALUE=uri:tel:+1-555-555-5555
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  END:VCARD
+....
+
+Upon inspecting the UID property, the second device matches the vCard
+it received to the vCard that it already has stored.  It then starts
+comparing the properties of the two vCards in same-named pairs.
+
+The FN properties are matched because the PID parameters have the
+same global value.  Since the property value is the same, no update
+takes place.
+
+The N properties are matched automatically because their maximum
+cardinality is 1.  Since the property value is the same, no update
+takes place.
+
+The EMAIL properties are matched because the PID parameters have the
+same global value.  Since the property value is the same, no update
+takes place.
+
+The TEL property in the new vCard is not matched to any in the stored
+vCard because no property in the stored vCard has the same name.
+Therefore, this property is copied from the new vCard to the stored
+vCard.
+
+The CLIENTPIDMAP property is handled separately by the
+synchronization engine.  It ensures that it is consistent with the
+stored one.  If it was not, the results would be up to the
+synchronization engine, and thus undefined by this document.
+
+[[section7_2_4]]
+====  Simultaneous Editing
+
+A new email address and a new phone number are added to the vCard on
+each of the two devices, and then a new synchronization event
+happens.  Here are the vCards that are communicated to each other:
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN;PID=1.1:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  EMAIL;PID=2.1:boss@example.com
+  TEL;PID=1.1;VALUE=uri:tel:+1-555-555-5555
+  TEL;PID=2.1;VALUE=uri:tel:+1-666-666-6666
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  END:VCARD
+....
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN;PID=1.1:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  EMAIL;PID=2.2:ceo@example.com
+  TEL;PID=1.1;VALUE=uri:tel:+1-555-555-5555
+  TEL;PID=2.2;VALUE=uri:tel:+1-666-666-6666
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  CLIENTPIDMAP:2;urn:uuid:1f762d2b-03c4-4a83-9a03-75ff658a6eee
+  END:VCARD
+....
+
+On the first device, the same PID source identifier (1) is reused for
+the new EMAIL and TEL properties.  On the second device, a new source
+identifier (2) is generated, and a corresponding CLIENTPIDMAP
+property is created.  It contains the second device's identifier,
+"urn:uuid:1f762d2b-03c4-4a83-9a03-75ff658a6eee".
+
+The new EMAIL properties are unmatched on both sides since the PID
+global value is new in both cases.  The sync thus results in a copy
+on both sides.
+
+Although the situation appears to be the same for the TEL properties,
+in this case, the synchronization engine is particularly smart and
+matches the two new TEL properties even though their PID global
+values are different.  Note that in this case, the rules of
+<<section7_1_2>> state that two properties [bcp14]#MAY# be matched at the
+discretion of the synchronization engine.  Therefore, the two
+properties are merged.
+
+All this results in the following vCard, which is stored on both
+devices:
+
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  EMAIL;PID=2.1:boss@example.com
+  EMAIL;PID=2.2:ceo@example.com
+  TEL;PID=1.1;VALUE=uri:tel:+1-555-555-5555
+  TEL;PID=2.1,2.2;VALUE=uri:tel:+1-666-666-6666
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  CLIENTPIDMAP:2;urn:uuid:1f762d2b-03c4-4a83-9a03-75ff658a6eee
+  END:VCARD
+....
+
+[[section7_2_5]]
+====  Global Context Simplification
+
+The two devices finish their synchronization procedure by simplifying
+their global contexts.  Since they haven't talked to any other
+device, the following vCard is for all purposes equivalent to the
+above.  It is also shorter.
+
+....
+  BEGIN:VCARD
+  VERSION:4.0
+  UID:urn:uuid:4fbe8971-0bc3-424c-9c26-36c3e1eff6b1
+  FN:J. Doe
+  N:Doe;J.;;;
+  EMAIL;PID=1.1:jdoe@example.com
+  EMAIL;PID=2.1:boss@example.com
+  EMAIL;PID=3.1:ceo@example.com
+  TEL;PID=1.1;VALUE=uri:tel:+1-555-555-5555
+  TEL;PID=2.1;VALUE=uri:tel:+1-666-666-6666
+  CLIENTPIDMAP:1;urn:uuid:53e374d9-337e-4727-8803-a1e9c14e0556
+  END:VCARD
+....
+
+The details of global context simplification are unspecified by this
+document.  They are left up to the synchronization engine.  This
+example is merely intended to illustrate the possibility, which
+investigating would be, in the author's opinion, worthwhile.
+
+[[section8]]
+==  Example: Author's vCard
+
+....
+ BEGIN:VCARD
+ VERSION:4.0
+ FN:Simon Perreault
+ N:Perreault;Simon;;;ing. jr,M.Sc.
+ BDAY:--0203
+ ANNIVERSARY:20090808T1430-0500
+ GENDER:M
+ LANG;PREF=1:fr
+ LANG;PREF=2:en
+ ORG;TYPE=work:Viagenie
+ ADR;TYPE=work:;Suite D2-630;2875 Laurier;
+  Quebec;QC;G1V 2M2;Canada
+ TEL;VALUE=uri;TYPE="work,voice";PREF=1:tel:+1-418-656-9254;ext=102
+ TEL;VALUE=uri;TYPE="work,cell,voice,video,text":tel:+1-418-262-6501
+ EMAIL;TYPE=work:simon.perreault@viagenie.ca
+ GEO;TYPE=work:geo:46.772673,-71.282945
+ KEY;TYPE=work;VALUE=uri:
+  http://www.viagenie.ca/simon.perreault/simon.asc
+ TZ:-0500
+ URL;TYPE=home:http://nomis80.org
+ END:VCARD
+....
+
+[[section9]]
+==  Security Considerations
+
+* Internet mail is often used to transport vCards and is subject to
+   many well-known security attacks, including monitoring, replay,
+   and forgery.  Care should be taken by any directory service in
+   allowing information to leave the scope of the service itself,
+   where any access controls or confidentiality can no longer be
+   guaranteed.  Applications should also take care to display
+   directory data in a "safe" environment.
+
+*  vCards can carry cryptographic keys or certificates, as described
+   in <<section6_8_1>>.
+
+*  vCards often carry information that can be sensitive (e.g.,
+   birthday, address, and phone information).  Although vCards have
+   no inherent authentication or confidentiality provisions, they can
+   easily be carried by any security mechanism that transfers MIME
+   objects to address authentication or confidentiality (e.g., S/MIME
+   <<RFC5751>>, OpenPGP <<RFC4880>>).  In cases where the confidentiality
+   or authenticity of information contained in vCard is a concern,
+   the vCard [bcp14]#SHOULD# be transported using one of these secure
+   mechanisms.  The KEY property (<<section6_8_1>>) can be used to
+   transport the public key used by these mechanisms.
+
+*  The information in a vCard may become out of date.  In cases where
+   the vitality of data is important to an originator of a vCard, the
+   SOURCE property (<<section6_1_3>>) [bcp14]#SHOULD# be specified.  In addition,
+   the "REV" type described in <<section6_7_4>> can be specified to
+   indicate the last time that the vCard data was updated.
+
+*  Many vCard properties may be used to transport URIs.  Please refer
+   to <<RFC3986,section=7>>, for considerations related to URIs.
+
+[[section10]]
+== IANA Considerations
+
+[[section10_1]]
+===  Media Type Registration
+
+IANA has registered the following Media Type (in
+http://www.iana.org) and marked the text/directory Media Type as
+DEPRECATED.
+
+To: :: \ietf-types@iana.org
+
+Subject: :: Registration of media type text/vcard
+
+Type name: :: text
+
+Subtype name: :: vcard
+
+Required parameters: :: none
+
+Optional parameters: :: version
++
+The "version" parameter is to be interpreted identically as the
+   VERSION vCard property.  If this parameter is present, all vCards
+   in a text/vcard body part [bcp14]#MUST# have a VERSION property with value
+   identical to that of this MIME parameter.
++
+"charset": as defined for text/plain <<RFC2046>>; encodings other
+   than UTF-8 <<RFC3629>> [bcp14]#MUST NOT# be used.
+
+Encoding considerations: :: 8bit
+
+Security considerations: :: See <<section9>>.
+
+Interoperability considerations: :: The text/vcard media type is
+   intended to identify vCard data of any version.  There are older
+   specifications of vCard <<RFC2426>> <<vCard21>> still in common use.
+   While these formats are similar, they are not strictly compatible.
+   In general, it is necessary to inspect the value of the VERSION
+   property (see <<section6_7_9>>) for identifying the standard to which
+   a given vCard object conforms.
++
+In addition, the following media types are known to have been used
+   to refer to vCard data.  They should be considered deprecated in
+   favor of text/vcard.
++
+*  text/directory
+*  text/directory; profile=vcard
+*  text/x-vcard
+
+Published specification: :: RFC 6350
+
+Applications that use this media type: :: They are numerous, diverse,
+   and include mail user agents, instant messaging clients, address
+   book applications, directory servers, and customer relationship
+   management software.
+
+Additional information: :: 
+
+Magic number(s): ::: 
+
+File extension(s): ::: .vcf .vcard
+
+Macintosh file type code(s): :::
+
+Person & email address to contact for further information: :: vCard
+   discussion mailing list <\vcarddav@ietf.org>
+
+Intended usage: :: COMMON
+
+Restrictions on usage: :: none
+
+Author: :: Simon Perreault
+
+Change controller: :: IETF
+
+[[section10_2]]
+===  Registering New vCard Elements
+
+This section defines the process for registering new or modified
+vCard elements (i.e., properties, parameters, value data types, and
+values) with IANA.
+
+[[section10_2_1]]
+====  Registration Procedure
+
+The IETF has created a mailing list, \vcarddav@ietf.org, which can be
+used for public discussion of vCard element proposals prior to
+registration.  Use of the mailing list is strongly encouraged.  The
+IESG has appointed a designated expert who will monitor the
+\vcarddav@ietf.org mailing list and review registrations.
+
+Registration of new vCard elements [bcp14]#MUST# be reviewed by the designated
+expert and published in an RFC.  A Standards Track RFC is [bcp14]#REQUIRED#
+for the registration of new value data types that modify existing
+properties.  A Standards Track RFC is also [bcp14]#REQUIRED# for registration
+of vCard elements that modify vCard elements previously documented in
+a Standards Track RFC.
+
+The registration procedure begins when a completed registration
+template, defined in the sections below, is sent to \vcarddav@ietf.org
+and \iana@iana.org.  Within two weeks, the designated expert is
+expected to tell IANA and the submitter of the registration whether
+the registration is approved, approved with minor changes, or
+rejected with cause.  When a registration is rejected with cause, it
+can be re-submitted if the concerns listed in the cause are
+addressed.  Decisions made by the designated expert can be appealed
+to the IESG Applications Area Director, then to the IESG.  They
+follow the normal appeals procedure for IESG decisions.
+
+Once the registration procedure concludes successfully, IANA creates
+or modifies the corresponding record in the vCard registry.  The
+completed registration template is discarded.
+
+An RFC specifying new vCard elements [bcp14]#MUST# include the completed
+registration templates, which [bcp14]#MAY# be expanded with additional
+information.  These completed templates are intended to go in the
+body of the document, not in the IANA Considerations section.
+
+Finally, note that there is an XML representation for vCard defined
+in <<RFC6351>>.  An XML representation [bcp14]#SHOULD# be defined for new vCard
+elements.
+
+[[section10_2_2]]
+====  Vendor Namespace
+
+The vendor namespace is used for vCard elements associated with
+commercially available products.  "Vendor" or "producer" are
+construed as equivalent and very broadly in this context.
+
+A registration may be placed in the vendor namespace by anyone who
+needs to interchange files associated with the particular product.
+However, the registration formally belongs to the vendor or
+organization handling the vCard elements in the namespace being
+registered.  Changes to the specification will be made at their
+request, as discussed in subsequent sections.
+
+vCard elements belonging to the vendor namespace will be
+distinguished by the "VND-" prefix.  This is followed by an IANA-
+registered Private Enterprise Number (PEN), a dash, and a vCard
+element designation of the vendor's choosing (e.g., "VND-123456-
+MUDPIE").
+
+While public exposure and review of vCard elements to be registered
+in the vendor namespace are not required, using the \vcarddav@ietf.org
+mailing list for review is strongly encouraged to improve the quality
+of those specifications.  Registrations in the vendor namespace may
+be submitted directly to the IANA.
+
+[[section10_2_3]]
+====  Registration Template for Properties
+
+A property is defined by completing the following template.
+
+Namespace: :: Empty for the global namespace, "VND-NNNN-" for a vendor-
+   specific property (where NNNN is replaced by the vendor's PEN).
+
+Property name: :: The name of the property.
+
+Purpose: :: The purpose of the property.  Give a short but clear
+   description.
+
+Value type: :: Any of the valid value types for the property value
+   needs to be specified.  The default value type also needs to be
+   specified.
+
+Cardinality: :: See <<section6>>.
+
+Property parameters: :: Any of the valid property parameters for the
+   property [bcp14]#MUST# be specified.
+
+Description: :: Any special notes about the property, how it is to be
+   used, etc.
+
+Format definition: :: The ABNF for the property definition needs to be
+   specified.
+
+Example(s): :: One or more examples of instances of the property need
+   to be specified.
+
+[[section10_2_4]]
+====  Registration Template for Parameters
+
+A parameter is defined by completing the following template.
+
+Namespace: :: Empty for the global namespace, "VND-NNNN-" for a vendor-
+   specific property (where NNNN is replaced by the vendor's PEN).
+
+Parameter name: :: The name of the parameter.
+
+Purpose: :: The purpose of the parameter.  Give a short but clear
+   description.
+
+Description: :: Any special notes about the parameter, how it is to be
+   used, etc.
+
+Format definition: :: The ABNF for the parameter definition needs to be
+   specified.
+
+Example(s): :: One or more examples of instances of the parameter need
+   to be specified.
+
+[[section10_2_5]]
+====  Registration Template for Value Data Types
+
+A value data type is defined by completing the following template.
+
+Value name: :: The name of the value type.
+
+Purpose: :: The purpose of the value type.  Give a short but clear
+   description.
+
+Description: :: Any special notes about the value type, how it is to be
+   used, etc.
+
+Format definition: :: The ABNF for the value type definition needs to
+   be specified.
+
+Example(s): :: One or more examples of instances of the value type need
+   to be specified.
+
+[[section10_2_6]]
+====  Registration Template for Values
+
+A value is defined by completing the following template.
+
+Value: :: The value literal.
+
+Purpose: :: The purpose of the value.  Give a short but clear
+   description.
+
+Conformance: :: The vCard properties and/or parameters that can take
+   this value needs to be specified.
+
+Example(s): :: One or more examples of instances of the value need to
+   be specified.
+
+The following is a fictitious example of a registration of a vCard
+value:
+
+Value: :: supervisor
+
+Purpose: :: It means that the related entity is the direct hierarchical
+   superior (i.e., supervisor or manager) of the entity this vCard
+   represents.
+
+Conformance: :: This value can be used with the "TYPE" parameter
+   applied on the "RELATED" property.
+
+
+Example(s): ::
++
+....
+RELATED;TYPE=supervisor:urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6
+....
+
+[[section10_3]]
+===  Initial vCard Elements Registries
+
+The IANA has created and will maintain the following registries for
+vCard elements with pointers to appropriate reference documents.  The
+registries are grouped together under the heading "vCard Elements".
+
+[[section10_3_1]]
+====  Properties Registry
+
+The following table has been used to initialize the properties
+registry.
+
+|===
+| Namespace | Property     | Reference               
+
+| |  SOURCE       | RFC 6350, Section 6.1.3 
+| |  KIND         | RFC 6350, Section 6.1.4 
+| |  XML          | RFC 6350, Section 6.1.5 
+| |  FN           | RFC 6350, Section 6.2.1 
+| |  N            | RFC 6350, Section 6.2.2 
+| |  NICKNAME     | RFC 6350, Section 6.2.3 
+| |  PHOTO        | RFC 6350, Section 6.2.4 
+| |  BDAY         | RFC 6350, Section 6.2.5 
+| |  ANNIVERSARY  | RFC 6350, Section 6.2.6 
+| |  GENDER       | RFC 6350, Section 6.2.7 
+| |  ADR          | RFC 6350, Section 6.3.1 
+| |  TEL          | RFC 6350, Section 6.4.1 
+| |  EMAIL        | RFC 6350, Section 6.4.2 
+| |  IMPP         | RFC 6350, Section 6.4.3 
+| |  LANG         | RFC 6350, Section 6.4.4 
+| |  TZ           | RFC 6350, Section 6.5.1 
+| |  GEO          | RFC 6350, Section 6.5.2 
+| |  TITLE        | RFC 6350, Section 6.6.1 
+| |  ROLE         | RFC 6350, Section 6.6.2 
+| |  LOGO         | RFC 6350, Section 6.6.3 
+| |  ORG          | RFC 6350, Section 6.6.4 
+| |  MEMBER       | RFC 6350, Section 6.6.5 
+| |  RELATED      | RFC 6350, Section 6.6.6 
+| |  CATEGORIES   | RFC 6350, Section 6.7.1 
+| |  NOTE         | RFC 6350, Section 6.7.2 
+| |  PRODID       | RFC 6350, Section 6.7.3 
+| |  REV          | RFC 6350, Section 6.7.4 
+| |  SOUND        | RFC 6350, Section 6.7.5 
+| |  UID          | RFC 6350, Section 6.7.6 
+| |  CLIENTPIDMAP | RFC 6350, Section 6.7.7 
+| |  URL          | RFC 6350, Section 6.7.8 
+| |  VERSION      | RFC 6350, Section 6.7.9 
+| |  KEY          | RFC 6350, Section 6.8.1 
+| |  FBURL        | RFC 6350, Section 6.9.1 
+| |  CALADRURI    | RFC 6350, Section 6.9.2 
+| |  CALURI       | RFC 6350, Section 6.9.3 
+|===
+
+
+[[section10_3_2]]
+====  Parameters Registry
+
+The following table has been used to initialize the parameters
+registry.
+
+|===
+| Namespace | Parameter | Reference              
+
+| |  LANGUAGE  | RFC 6350, Section 5.1  
+| |  VALUE     | RFC 6350, Section 5.2  
+| |  PREF      | RFC 6350, Section 5.3  
+| |  ALTID     | RFC 6350, Section 5.4  
+| |  PID       | RFC 6350, Section 5.5  
+| |  TYPE      | RFC 6350, Section 5.6  
+| |  MEDIATYPE | RFC 6350, Section 5.7  
+| |  CALSCALE  | RFC 6350, Section 5.8  
+| |  SORT-AS   | RFC 6350, Section 5.9  
+| |  GEO       | RFC 6350, Section 5.10 
+| |  TZ        | RFC 6350, Section 5.11 
+|===
+
+[[section10_3_3]]
+====  Value Data Types Registry
+
+The following table has been used to initialize the parameters
+registry.
+
+|===
+| Value Data Type  | Reference               
+
+| BOOLEAN          | RFC 6350, Section 4.4   
+| DATE             | RFC 6350, Section 4.3.1 
+| DATE-AND-OR-TIME | RFC 6350, Section 4.3.4 
+| DATE-TIME        | RFC 6350, Section 4.3.3 
+| FLOAT            | RFC 6350, Section 4.6   
+| INTEGER          | RFC 6350, Section 4.5   
+| LANGUAGE-TAG     | RFC 6350, Section 4.8   
+| TEXT             | RFC 6350, Section 4.1   
+| TIME             | RFC 6350, Section 4.3.2 
+| TIMESTAMP        | RFC 6350, Section 4.3.5 
+| URI              | RFC 6350, Section 4.2   
+| UTC-OFFSET       | RFC 6350, Section 4.7   
+|===
+
+[[section10_3_4]]
+====  Values Registries
+
+Separate tables are used for property and parameter values.
+
+The following table is to be used to initialize the property values
+registry.
+
+|===
+| Property | Value      | Reference               
+
+| BEGIN    | VCARD      | RFC 6350, Section 6.1.1 
+| END      | VCARD      | RFC 6350, Section 6.1.2 
+| KIND     | individual | RFC 6350, Section 6.1.4 
+| KIND     | group      | RFC 6350, Section 6.1.4 
+| KIND     | org        | RFC 6350, Section 6.1.4 
+| KIND     | location   | RFC 6350, Section 6.1.4 
+|===
+
+The following table has been used to initialize the parameter values
+registry.
+
+[cols="4"]
+|===
+| Property               | Parameter | Value        | Reference     
+
+| FN, NICKNAME, PHOTO,   
+ ADR, TEL, EMAIL, IMPP, 
+ LANG, TZ, GEO, TITLE,  
+ ROLE, LOGO, ORG,       
+ RELATED, CATEGORIES,   
+ NOTE, SOUND, URL, KEY, 
+ FBURL, CALADRURI, and  
+ CALURI                 
+| TYPE      | work         | RFC 6350, Section 5.6
+
+| FN, NICKNAME, PHOTO,   
+ ADR, TEL, EMAIL, IMPP, 
+ LANG, TZ, GEO, TITLE,  
+ ROLE, LOGO, ORG,       
+ RELATED, CATEGORIES,   
+ NOTE, SOUND, URL, KEY, 
+ FBURL, CALADRURI, and  
+ CALURI                 
+| TYPE      | home         | RFC 6350, Section 5.6
+
+| TEL       | TYPE      | text         | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | voice        | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | fax          | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | cell         | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | video        | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | pager        | RFC 6350, Section 6.4.1 
+| TEL       | TYPE      | textphone    | RFC 6350, Section 6.4.1 
+
+| BDAY, ANNIVERSARY      | CALSCALE    | gregorian    
+| RFC 6350, Section 5.8   
+
+| RELATED   | TYPE      | contact      
+| RFC 6350, Section 6.6.6 and <<xfn>>     
+
+| RELATED   | TYPE      | acquaintance 
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | friend       
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | met          
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | co-worker    
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | colleague    
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | co-resident  
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | neighbor     
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | child        
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | parent       
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | sibling      
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | spouse       
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | kin          
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | muse         
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | crush        
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | date         
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | sweetheart   
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | me           
+| RFC 6350, Section 6.6.6 and <<xfn>>
+
+| RELATED   | TYPE      | agent        | RFC 6350, Section 6.6.6 
+| RELATED   | TYPE      | emergency    | RFC 6350, Section 6.6.6 
+|===
+
+
+[[section11]]
+==  Acknowledgments
+
+The authors would like to thank Tim Howes, Mark Smith, and Frank
+Dawson, the original authors of <<RFC2425>> and <<RFC2426>>, Pete
+Resnick, who got this effort started and provided help along the way,
+as well as the following individuals who have participated in the
+drafting, review, and discussion of this memo:
+
+Aki Niemi, Andy Mabbett, Alexander Mayrhofer, Alexey Melnikov, Anil
+Srivastava, Barry Leiba, Ben Fortuna, Bernard Desruisseaux, Bernie
+Hoeneisen, Bjoern Hoehrmann, Caleb Richardson, Chris Bryant, Chris
+Newman, Cyrus Daboo, Daisuke Miyakawa, Dan Brickley, Dan Mosedale,
+Dany Cauchie, Darryl Champagne, Dave Thewlis, Filip Navara, Florian
+Zeitz, Helge Hess, Jari Urpalainen, Javier Godoy, Jean-Luc Schellens,
+Joe Hildebrand, Jose Luis Gayosso, Joseph Smarr, Julian Reschke,
+Kepeng Li, Kevin Marks, Kevin Wu Won, Kurt Zeilenga, Lisa Dusseault,
+Marc Blanchet, Mark Paterson, Markus Lorenz, Michael Haardt, Mike
+Douglass, Nick Levinson, Peter K. Sheerin, Peter Mogensen, Peter
+Saint-Andre, Renato Iannella, Rohit Khare, Sly Gryphon, Stephane
+Bortzmeyer, Tantek Celik, and Zoltan Ordogh.
+
+[bibliography]
+==  Normative References
+
+* [[[CCITT.X520.1988]]] International Telephone and Telegraph Consultative Committee, "Information Technology - Open Systems Interconnection - The Directory: Selected Attribute Types", CCITT Recommendation X.520, November 1988.
+* [[[IEEE.754.2008]]] Institute of Electrical and Electronics Engineers, "Standard for Binary Floating-Point Arithmetic", IEEE Standard 754, August 2008.
+* [[[ISO.8601.2000]]] International Organization for Standardization, "Data elements and interchange formats - Information interchange - Representation of dates and times", ISO Standard 8601, December 2000.
+* [[[ISO.8601.2004]]] International Organization for Standardization, "Data elements and interchange formats - Information interchange - Representation of dates and times", ISO Standard 8601, December 2004.
+* [[[RFC2045,RFC 2045]]]
+* [[[RFC2046,RFC 2046]]]
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC2739,RFC 2739]]]
+* [[[RFC3629,RFC 3629]]]
+* [[[RFC3966,RFC 3966]]]
+* [[[RFC3986,RFC 3986]]]
+* [[[RFC4122,RFC 4122]]]
+* [[[RFC4288,RFC 4288]]]
+* [[[RFC5234,RFC 5234]]]
+* [[[RFC5322,RFC 5322]]]
+* [[[RFC5545,RFC 5545]]]
+* [[[RFC5546,RFC 5546]]]
+* [[[RFC5646,RFC 5646]]]
+* [[[RFC5870,RFC 5870]]]
+* [[[RFC6351,RFC 6351]]]
+* [[[W3C.REC-xml-20081126]]] Bray, T., Paoli, J., Sperberg-McQueen, C., Maler, E., and F. Yergeau, "Extensible Markup Language (XML) 1.0 (Fifth Edition)", World Wide Web Consortium Recommendation REC-xml-20081126, November 2008, http://www.w3.org/TR/2008/REC-xml-20081126.
+* [[[xfn]]] Celik, T., Mullenweg, M., and E. Meyer, "XFN 1.1 profile", October 2003, http://gmpg.org/xfn/11.
+
+[bibliography]
+==  Informative References
+
+* [[[IANA-TZ]]] Lear, E. and P. Eggert, "IANA Procedures for Maintaining the Timezone Database", May 2011.
+* [[[ISO9070]]] International Organization for Standardization, "Information Processing - SGML support facilities - Registration Procedures for Public Text Owner Identifiers", ISO Standard 9070, April 1991.
+* [[[RFC1738,RFC 1738]]]
+* [[[RFC2397,RFC 2397]]]
+* [[[RFC2425,RFC 2425]]]
+* [[[RFC2426,RFC 2426]]]
+* [[[RFC2616,RFC 2616]]]
+* [[[RFC3282,RFC 3282]]]
+* [[[RFC3406,RFC 3406]]]
+* [[[RFC3536,RFC 3536]]]
+* [[[RFC4770,RFC 4770]]]
+* [[[RFC4880,RFC 4880]]]
+* [[[RFC5335bis,RFC 5335]]]
+* [[[RFC5751,RFC 5751]]]
+* [[[RFC6068,RFC 6068]]]
+* [[[TZ-DB]]] Olson, A., "Time zone code and data", August 2011, ftp://elsie.nci.nih.gov/pub/.
+* [[[vCard21]]] Internet Mail Consortium, "vCard - The Electronic Business Card Version 2.1", September 1996.
+
+[[appendixA]]
+== Differences from RFCs 2425 and 2426
+
+This appendix contains a high-level overview of the major changes
+that have been made in the vCard specification from RFCs 2425 and
+2426.  It is incomplete, as it only lists the most important changes.
+
+[[appendixA_1]]
+===  New Structure
+
+*  <<RFC2425>> and <<RFC2426>> have been merged.
+
+*  vCard is now not only a MIME type but a stand-alone format.
+
+*  A proper MIME type registration form has been included.
+
+*  UTF-8 is now the only possible character set.
+
+*  New vCard elements can be registered from IANA.
+
+[[appendixA_2]]
+===  Removed Features
+
+*  The CONTEXT and CHARSET parameters are no more.
+
+*  The NAME, MAILER, LABEL, and CLASS properties are no more.
+
+*  The "intl", "dom", "postal", and "parcel" TYPE parameter values
+   for the ADR property have been removed.
+
+*  In-line vCards (such as the value of the AGENT property) are no
+   longer supported.
+
+[[appendixA_3]]
+===  New Properties and Parameters
+
+*  The KIND, GENDER, LANG, ANNIVERSARY, XML, and CLIENTPIDMAP
+   properties have been added.
+
+*  <<RFC2739>>, which defines the FBURL, CALADRURI, CAPURI, and CALURI
+   properties, has been merged in.
+
+*  <<RFC4770>>, which defines the IMPP property, has been merged in.
+
+*  The "work" and "home" TYPE parameter values are now applicable to
+   many more properties.
+
+*  The "pref" value of the TYPE parameter is now a parameter of its
+   own, with a positive integer value indicating the level of
+   preference.
+
+*  The ALTID and PID parameters have been added.
+
+*  The MEDIATYPE parameter has been added and replaces the TYPE
+   parameter when it was used for indicating the media type of the
+   property's content.
+
+
+
+

--- a/sources/rfc748/document.adoc
+++ b/sources/rfc748/document.adoc
@@ -3,6 +3,7 @@ M. Crispin
 :doctype: internet-draft
 :abbrev: TELNET RANDOMLY-LOSE Option
 :status: info
+:intended-series: informational
 :name: rfc-748
 :docnumber: 748
 :ipr: trust200902

--- a/sources/rfc748/document.adoc
+++ b/sources/rfc748/document.adoc
@@ -1,0 +1,83 @@
+= TELNET RANDOMLY-LOSE Option
+M. Crispin
+:doctype: internet-draft
+:abbrev: TELNET RANDOMLY-LOSE Option
+:status: info
+:name: rfc-748
+:docnumber: 748
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 1978-04-01T00:00:00Z
+:fullname: M. Crispin
+:surname: Crispin
+:initials: M.
+:organization: SU-AI
+:smart-quotes: false
+
+== Command name and code
+
+[align=center]
+....
+RANDOMLY-LOSE    256
+....
+
+== Command meanings
+
+IAC WILL RANDOMLY-LOSE: ::
++
+The sender of this command REQUESTS permission to, or confirms
+that it will, randomly lose.
+
+IAC WON'T RANDOMLY-LOSE: ::
++
+The sender of this command REFUSES to randomly lose.
+
+IAC DO RANDOMLY-LOSE: ::
++
+The sender of this command REQUESTS that the receiver, or grants
+the receiver permission to, randomly lose.
+
+IAC DON'T RANDOMLY-LOSE: ::
++
+The command sender DEMANDS that the receiver not randomly lose.
+
+== Default
+
+....
+    WON'T RANDOMLY-LOSE
+
+    DON'T RANDOMLY-LOSE
+....
+
+i.e., random lossage will not happen.
+
+== Motivation for the option
+
+Several hosts appear to provide random lossage, such as system
+crashes, lost data, incorrectly functioning programs, etc., as part
+of their services. These services are often undocumented and are in
+general quite confusing to the novice user.  A general means is
+needed to allow the user to disable these features.
+
+== Description of the option
+
+The normal mode does not allow random lossage; therefore the system
+is not allowed to crash, mung user files, etc. If the server wants
+to provide random lossage, it must first ask for permission from the
+user by sending IAC WILL RANDOMLY-LOSE.
+
+If the user wants to permit the server to randomly lose, it replys
+with IAC DO  RANDOMLY-LOSE. Otherwise it  sends  IAC  DONT
+RANDOMLY-LOSE, and the server is forbidden from randomly losing.
+
+Alternatively, the user could request the server to randomly lose, by
+sending IAC DO RANDOMLY-LOSE, and the server will either reply with
+IAC WILL RANDOMLY-LOSE, meaning that it will then proceed to do some
+random lossage (garbaging disk files is recommended for an initial
+implementation).  Or, it could send IAC WONT RANDOMLY-LOSE, meaning
+that it insists upon being reliable.
+
+Since this is implemented as a TELNET option, it is expected that
+servers which do not implement this option will not randomly lose;
+ie, they will provide 100% reliable uptime.

--- a/sources/rfc7511/document.adoc
+++ b/sources/rfc7511/document.adoc
@@ -3,6 +3,7 @@ Maximilian Wilhelm <max@rfc2324.org>
 :doctype: internet-draft
 :abbrev: Scenic Routing for IPv6
 :status: info
+:intended-series: informational
 :name: rfc-7511
 :docnumber: 7511
 :ipr: trust200902

--- a/sources/rfc7511/document.adoc
+++ b/sources/rfc7511/document.adoc
@@ -1,0 +1,288 @@
+= Scenic Routing for IPv6
+Maximilian Wilhelm <max@rfc2324.org>
+:doctype: internet-draft
+:abbrev: Scenic Routing for IPv6
+:status: info
+:name: rfc-7511
+:docnumber: 7511
+:ipr: trust200902
+:area: Internet
+:workgroup: Network Working Group
+:revdate: 2015-04-01T00:00:00Z
+:fullname: Maximilian Wilhelm
+:surname: Wilhelm
+:givenname: Maximilian
+:initials: M.
+:email: max@rfc2324.org
+:phone: +49 176 62 05 94 27
+:city: Paderborn, NRW
+:country: Germany
+:smart-quotes: false
+
+This document specifies a new routing scheme for the current version
+of the Internet Protocol version 6 (IPv6) in the spirit of "Green
+IT", whereby packets will be routed to get as much fresh-air time as
+possible.
+
+== Introduction
+
+In times of Green IT, a lot of effort is put into reducing the energy
+consumption of routers, switches, servers, hosts, etc., to preserve
+our environment.  This document looks at Green IT from a different
+angle and focuses on network packets being routed and switched around
+the world.
+
+Most likely, no one ever thought about the millions of packets being
+disassembled into bits every second and forced through copper wires
+or being shot through dark fiber lines by powerful lasers at
+continuously increasing speeds.  Although RFC 5841 <<RFC5841>> provided
+some thoughts about Packet Moods and began to represent them as a TCP
+option, this doesn't help the packets escape their torturous routine.
+
+This document defines another way to deal with Green IT for traffic
+and network engineers and will hopefully aid the wellbeing of a
+myriad of network packets around the world.  It proposes Scenic
+Routing, which incorporates the green-ness of a network path into the
+routing decision.  A routing engine implementing Scenic Routing
+should therefore choose paths based on Avian IP Carriers <<RFC1149>>
+and/or wireless technologies so the packets will get out of the
+miles/kilometers of dark fibers that are in the ground and get as
+much fresh-air time and sunlight as possible.
+
+As of the widely known acceptance of the current version of the
+Internet Protocol (IPv6), this document only focuses on version 6 and
+ignores communication still based on Vintage IP <<RFC0791>>.
+
+===  Conventions and Terminology
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
+"**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this
+document are to be interpreted as described in RFC 2119 <<RFC2119>>.
+
+Additionally, the key words "**MIGHT**", "**COULD**", "**MAY WISH TO**", 
+"**WOULD PROBABLY**", "**SHOULD CONSIDER**", and "**MUST (BUT WE KNOW YOU WON'T)**" in
+this document are to interpreted as described in RFC 6919 <<RFC6919>>.
+
+==  Scenic Routing
+
+Scenic Routing can be enabled with a new option for IPv6 datagrams.
+
+[[scenic-routing-option-sro]]
+===  Scenic Routing Option (SRO)
+
+The Scenic Routing Option (SRO) is placed in the IPv6 Hop-by-Hop
+Options Header that must be examined by every node along a packet's
+delivery path <<RFC2460>>.
+
+The SRO can be included in any IPv6 datagram, but multiple SROs [bcp14]#MUST NOT# be present in the same IPv6 datagram.  The SRO has no alignment
+requirement.
+
+If the SRO is set for a packet, every node en route from the packet
+source to the packet's final destination **MUST** preserve the option.
+
+The following Hop-by-Hop Option is proposed according to the
+specification in <<RFC2460,4.2 of: RFC 2460>>.
+
+[#fig-scenic-routing-option-layout]
+.Scenic Routing Option Layout
+[align=center]
+====
+[align=center]
+....
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+                                +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                                |  Option Type  | Option Length |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   SRO Param   |                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+....
+====
+
+Option Type:: 
++
+--
+8-bit identifier of the type of option.  The option identifier
+0x0A (On Air) is proposed for Scenic Routing.
+
+[#fig-option-type]
+.Scenic Routing Option Type
+[align=center]
+====
+[align=center]
+....
+HEX         act  chg  rest
+---         ---  ---  -----
+0A           00   0   01010     Scenic Routing
+....
+====
+
+{blank} +
+The highest-order two bits are set to 00 so any node not
+    implementing Scenic Routing will skip over this option and
+    continue processing the header.  The third-highest-order bit
+    indicates that the SRO does not change en route to the packet's
+    final destination.
+--
+
+Option Length:: 
++
+--
+8-bit unsigned integer.  The length of the option in octets
+    (excluding the Option Type and Option Length fields).  The value
+    **MUST** be greater than 0.
+--
+
+SRO Param::
++
+--
+8-bit identifier indicating Scenic Routing parameters encoded as a bit string.
+
+[#fig-bit-string-layout]
+.SRO Param Bit String Layout
+[align=center]
+====
+[align=center]
+....
++-+-+-+-+-+-+-+-+
+| SR A W AA X Y |
++-+-+-+-+-+-+-+-+
+....
+====
+
+The highest-order two bits (SR) define the urgency of Scenic
+    Routing:
+
+[empty]
+* 00 - Scenic Routing **MUST NOT** be used for this packet.
+* 01 - Scenic Routing **MIGHT** be used for this packet.
+* 10 - Scenic Routing **SHOULD** be used for this packet.
+* 11 - Scenic Routing **MUST** be used for this packet.
+
+The following BIT (A) defines if Avian IP Carriers should be used:
+
+[empty]
+* 0 - Don't use Avian IP Carrier links (maybe the packet is
+      afraid of pigeons).
+* 1 - Avian IP Carrier links may be used.
+
+The following BIT (W) defines if wireless links should be used:
+
+[empty]
+* 0 - Don't use wireless links (maybe the packet is afraid of
+      radiation).
+* 1 - Wireless links may be used.
+
+The following two bits (AA) define the affinity for link types:
+
+[empty]
+* 00 - No affinity.
+* 01 - Avian IP Carriers **SHOULD** be preferred.
+* 10 - Wireless links **SHOULD** be preferred.
+* 11 - RESERVED
+
+The lowest-order two bits (XY) are currently unused and reserved
+    for future use.
+--
+
+== Implications
+
+=== Routing Implications
+
+If Scenic Routing is requested for a packet, the path with the known
+longest Avian IP Carrier and/or wireless portion **MUST** be used.
+
+Backbone operators who desire to be fully compliant with Scenic
+Routing **MAY WISH TO** -- well, they **SHOULD** -- have separate MPLS paths
+ready that provide the most fresh-air time for a given path and are
+to be used when Scenic Routing is requested by a packet.  If such a
+path exists, the path **MUST** be used in favor of any other path, even
+if another path is considered cheaper according to the path costs
+used regularly, without taking Scenic Routing into account.
+
+=== Implications for Hosts
+
+Host systems implementing this option of receiving packets with
+Scenic Routing requested **MUST** honor this request and **MUST** activate
+Scenic Routing for any packets sent back to the originating host for
+the current connection.
+
+If Scenic Routing is requested for connections of local origin, the
+host **MUST** obey the request and route the packet(s) over a wireless
+link or use Avian IP Carriers (if available and as requested within
+the SRO Params).
+
+System administrators **MIGHT** want to configure sensible default
+parameters for Scenic Routing, when Scenic Routing has been widely
+adopted by operating systems.  System administrators **SHOULD** deploy
+Scenic Routing information where applicable.
+
+===  Proxy Servers
+
+If a host is running a proxy server or any other packet-relaying
+application, an application implementing Scenic Routing **MUST** set the
+same SRO Params on the outgoing packet as seen on the incoming
+packet.
+
+Developers **SHOULD CONSIDER** Scenic Routing when designing and
+implementing any network service.
+
+==  Security Considerations
+
+The security considerations of RFC 6214 <<RFC6214>> apply for links
+provided by Avian IP Carriers.
+
+General security considerations of wireless communication apply for
+links using wireless technologies.
+
+As the user is able to influence where flows and packets are being
+routed within the network, this **MIGHT** influence traffic-engineering
+considerations and network operators **MAY WISH TO** take this into
+account before enabling Scenic Routing on their devices.
+
+==  IANA Considerations
+
+This document defines a new IPv6 Hop-by-Hop Option, the Scenic
+Routing Option, described in <<scenic-routing-option-sro>>.
+If this work is standardized, IANA is requested to assign a value from the "Destination Options and
+Hop-by-Hop Options" registry for the purpose of Scenic Routing.
+
+There are no IANA actions requested at this time.
+
+==  Related Work
+
+As Scenic Routing is heavily dependent on network paths and routing
+information, it might be worth looking at designing extensions for
+popular routing protocols like BGP or OSPF to leverage the full
+potential of Scenic Routing in large networks built upon lots of
+wireless links and/or Avian IP Carriers.  When incorporating
+information about links compatible with Scenic Routing, the routing
+algorithms could easily calculate the optimal paths providing the
+most fresh-air time for a packet for any given destination.
+
+This would even allow preference for wireless paths going alongside
+popular or culturally important places.  This way, the packets don't
+only avoid the dark fibers, but they get to see the world outside of
+the Internet and are exposed to different cultures around the globe,
+which may help build an understanding of cultural differences and
+promote acceptance of these differences.
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC2460,RFC 2460]]]
+* [[[RFC5841,RFC 5841]]]
+* [[[RFC6214,RFC 6214]]]
+* [[[RFC6919,RFC 6919]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC0791,RFC 791]]]
+* [[[RFC1149,RFC 1149]]]
+
+== Acknowledgements
+
+The author wishes to thank all those poor friends who were kindly
+forced to read this document and that provided some nifty comments.

--- a/sources/skel/document.adoc
+++ b/sources/skel/document.adoc
@@ -4,6 +4,7 @@ Carsten Bormann <cabo@tzi.org>
 :abbrev: mfld
 :name: draft-mfld-00
 :status: informational
+:intended-series: informational
 :toc-include: yes
 :sort-refs: yes
 :sym-refs: yes

--- a/sources/skel/document.adoc
+++ b/sources/skel/document.adoc
@@ -1,0 +1,34 @@
+= Many fine lunches and dinners
+Carsten Bormann <cabo@tzi.org>
+:doctype: internet-draft
+:abbrev: mfld
+:name: draft-mfld-00
+:status: informational
+:toc-include: yes
+:sort-refs: yes
+:sym-refs: yes
+:fullname: Carsten Bormann
+:surname: Bormann
+:givenname: Carsten
+:initials: C.
+:organization: Universität Bremen TZI
+:street: Postfach 330440
+:city: Bremen
+:code: D-28359
+:country: Germany
+:phone: +49-421-218-63921
+:email: cabo@tzi.org
+:revdate: 2017-11-03
+:comments: yes
+:rfc2629xslt: true
+
+insert abstract here
+
+== Introduction
+
+This MAY <<RFC2119>> be useful.
+
+[bibliography]
+== Informative References
+
+* [[[RFC2119,RFC 2119]]]

--- a/sources/stupid-s/document.adoc
+++ b/sources/stupid-s/document.adoc
@@ -5,6 +5,7 @@ Klaus Hartke <hartke@tzi.org>; Carsten Bormann <cabo@tzi.org>
 :name: draft-hartke-xmpp-stupid-00
 :revdate: 2009-07-05
 :status: informational
+:intended-series: informational
 :ipr: trust200902
 :area: General
 :workgroup: XMPP Working Group

--- a/sources/stupid-s/document.adoc
+++ b/sources/stupid-s/document.adoc
@@ -1,0 +1,585 @@
+= STUN/TURN using PHP in Despair
+Klaus Hartke <hartke@tzi.org>; Carsten Bormann <cabo@tzi.org>
+:doctype: internet-draft
+:abbrev: STuPiD
+:name: draft-hartke-xmpp-stupid-00
+:revdate: 2009-07-05
+:status: informational
+:ipr: trust200902
+:area: General
+:workgroup: XMPP Working Group
+:keyword: Internet-Draft
+:toc-include: yes
+:sort-refs: yes
+:sym-refs: yes
+:fullname: Klaus Hartke
+:surname: Hartke
+:givenname: Klaus
+:initials: K.
+:email: hartke@tzi.org
+:organization: Universität Bremen TZI
+:fullname_2: Carsten Bormann
+:surname_2: Bormann
+:givenname_2: Carsten
+:initials_2: C.
+:email_2: cabo@tzi.org
+:organization_2: Universität Bremen TZI
+:street_2: Postfach 330440
+:city_2: Bremen
+:code_2: D-28359
+:country_2: Germany
+:phone_2: +49-421-218-63921
+:fax_2: +49-421-218-7000
+:rfc2629xslt: true
+
+NAT (Network Address Translator) Traversal may require TURN
+(Traversal Using Relays around NAT) functionality in certain
+cases that are not unlikely to occur.  There is little
+incentive to deploy TURN servers, except by those who need
+them — who may not be in a position to deploy a new protocol
+on an Internet-connected node, in particular not one with
+deployment requirements as high as those of TURN.
+
+"STUN/TURN using PHP in Despair" is a highly deployable
+protocol for obtaining TURN-like functionality, while also
+providing the most important function of STUN.
+
+[#problems]
+== Introduction        
+
+NAT (Network Address Translator) Traversal may require TURN
+(Traversal Using Relays around NAT)
+<<I-D.ietf-behave-turn>>
+functionality in certain
+cases that are not unlikely to occur.  There is little
+incentive to deploy TURN servers, except by those who need
+them — who may not be in a position to deploy a new protocol
+on an Internet-connected node, in particular not one with
+deployment requirements as high as those of TURN.
+
+"STUN/TURN using PHP in Despair" is a highly deployable
+protocol for obtaining TURN-like functionality, while also
+providing the most important function of STUN
+<<RFC5389>>.
+
+The high degree of deployability is achieved by making STuPiD
+a Web service, implementable in any Web application deployment
+scheme.  As PHP appears to be the solution of choice for
+avoiding deployment problems in the Web world, a PHP-based
+sample implementation of STuPiD is presented in <<figimpl>> in <<impl>>.
+(This single-page script has been tested with a free-of-charge
+web hoster, so it should be deployable by literally everyone.)
+
+[#need]
+=== The Need for Standardization   
+
+If STuPiD is so easy to deploy, why standardize on it?
+First of all, STuPiD server implementations will be done by
+other people than the clients making use of the service.
+Clearly communicating between these communities is a good
+idea, in particular if there are security considerations.
+
+Having one standard form of STuPiD service instead of one
+specific to each kind of client also creates an incentive
+for optimized implementations.
+
+Finally, where STuPiD becomes part of a client standard
+(such as a potential extension to XMPP's in-band byte-stream
+protocol as hinted in <<xmpp>>), it is a good
+thing if STuPiD is already defined.
+
+Hence, this document focuses on the definition of the STuPiD
+service itself, tries to make this as general as possible
+without increasing complexity or cost and leaves the details
+of any client standards to future documents.
+
+[#ops]
+== Basic Protocol Operation 
+
+The STuPiD protocol will typically be used with application
+instances that first attempt to obtain connectivity using
+mechanisms similar to those described in the STUN
+specification <<RFC5389>>.  However, with STuPiD,
+STUN is not really needed for TCP, as was demonstrated in
+previous STUN-like implementations <<STUNT>>.
+Instead, STuPiD (like <<STUNT>>) provides a
+simple Web service that
+echoes the remote address and port of an incoming HTTP
+request; in most cases, this is enough to get the job done.
+
+In case no connection can be established with this simple
+STUN(T)-like mechanism, a TURN-like relay is needed as a final
+fall-back.
+The STuPiD protocol supports this, but solely provides a way
+for the data to be
+relayed.  STuPiD relies on an out-of-band channel to notify
+the peer whenever new data is available (synchronization signal).
+See <<xmpp>> for one likely example of such an
+out-of-band channel.
+(Note that the out-of-band channel may have a much lower
+throughput than the STuPiD relay channel — this is exactly
+the case in the example provided in <<xmpp>>,
+where the out-of-band channel is typically throughput-limited
+to on the order of a few kilobits per second.)
+
+By designing the STuPiD web service in such a way that it can
+be implemented by a simple PHP script such as that presented
+in <<impl>>, it is easy to deploy by those who
+need the STuPiD services.
+The combination of the low-throughput out-of-band channel for
+synchronization and the STuPiD web service for bulk data
+relaying is somewhat silly but gets the job done.
+
+The STuPiD data relay is implemented as follows (see <<figops>>):
+
+. Peer A, the source of the data to be relayed, stores a chunk of
+   data at the STuPiD server using an opaque identifier, the "chunk
+   identifier". How that chunk identifier is chosen is local to Peer
+   A; it could be composed of a random session id and a sequence number.
+. Peer A notifies the receiver of the data, Peer
+   B, that a new data chunk is available, specifying the URI needed
+   for retrieval.
+   This notification is provided through an out-out-band channel.
+   (As an optimization for multiple consecutive transfers, A might
+   inform B once of a constant prefix of that URI and only send a
+   varying part such as a sequence number in each notification —
+   this is something to be decided in the client-client notification
+   protocol.)
+. Peer B retrieves the data from the STuPiD server using the URI
+   provided by Peer A.
+
+Note that the data transfer mechanism is one-way, i.e. to send
+data in the other direction as well, Peer B needs to perform
+the same steps using a STuPiD server at the same or a
+different location.
+
+[#figops]
+.STuPiD Protocol Operation
+====
+....
+
+        STuPiD   ```````````````````````````````,
+        Script   <----------------------------. ,
+                                              | ,
+          ^ ,                                 | ,
+          | ,                                 | ,
+    (1)   | ,                                 | ,  (3)
+    POST  | ,                                 | ,  GET
+          | ,                                 | ,
+          | v                                 | v
+
+        Peer A   ----------------------->   Peer B
+                           (2)
+                       out-of-band
+                       Notification
+....
+====
+
+
+== Protocol Definition
+
+[#Terminology]
+=== Terminology          
+
+In this document, the key words "**MUST**", "**MUST NOT**", "**REQUIRED**",
+"**SHALL**", "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**MAY**",
+and "**OPTIONAL**" are to be interpreted as described in BCP 14, RFC 2119
+<<RFC2119>> and indicate requirement levels for compliant STuPiD
+implementations.
+
+
+=== Discovering External IP Address and Port
+
+A client may discover its external IP address and the port
+required for port prediction by performing a HTTP GET
+request to a STuPiD server. The STuPiD server **MUST** reply
+with the remote address and remote port in the following
+format:
+
+host ":" port
+
+where 'host' and 'port' are defined as in <<RFC3986>>.
+
+
+=== Storing Data
+
+Data chunks are stored using the POST request of HTTP. The
+STuPiD server **MUST** support one URI parameter which is passed
+as query-string:
+
+'chid':  A unique ID identifying the data chunk to be stored.
+The ID **SHOULD** be chosen from the characters of the base64url
+set <<RFC4648>>.
+
+The payload of the POST request **MUST** be the data to be
+stored. The 'Content-Type' **SHOULD** be
+'application/octet-stream', although a STuPiD server
+implementation **SHOULD** simply ignore the 'Content-Type' as a
+client implementation may be restricted and may not able to
+specify a specific 'Content-Type'.  (E.g., in certain cases,
+the peer may be limited to sending the data as
+multipart-form-encoded — still, the data is stored as a
+byte stream.)
+
+STuPiD servers may reject data chunks that are larger than
+some predefined limit.
+This maximum size in bytes of each data chunk is **RECOMMENDED**
+to be 65536 or more.
+
+As HTTP already provides data transparency,
+the data chunk **SHOULD NOT** be encoded using Base64 or any
+other data transparency mechanism; in any case, the STuPiD
+server will not attempt to decode the chunk.
+
+The sender **MUST** wait for the HTTP response before
+going on to notify the receiver.
+
+
+=== Notification
+
+The sender notifies the receiver of the data chunk by passing
+via an out-of-band channel (which is not part of the STuPiD
+protocol):
+
+The full URL from which the data chunk can be retrieved,
+i.e. the same URL that was used to store the data chunk,
+including the chunk ID parameter.
+
+The exact notification mechanism over the out-of-band channel
+and the definition of a session is dependent on the
+out-of-band channel.  See <<xmpp>> for one
+example of such an out-of-band channel.
+
+
+=== Retrieving Data
+
+The notified peer retrieves the data chunk using a GET request
+with the URL supplied by the sender. The STuPiD server **MUST**
+set the 'Content-Type' of the returned body to
+'application/octet-stream'.
+
+
+== Implementation Notes
+
+A STuPiD server implementation **SHOULD** delete stored data some
+time after it was stored. It is **RECOMMENDED** not to delete the
+data before five minutes have elapsed after it was stored.
+Different client protocols will have different reactions to
+data that have been deleted prematurely and cannot be
+retrieved by the notified peer; this may be as trivial as
+packet loss or it may cause a reliable byte-stream to fail
+(<<impl>>).
+(TODO: It may be useful to provide some hints in the storing
+POST request.)
+
+STuPiD clients should aggregate data in order to minimize the
+number of requests to the STuPiD server per second.
+The specific aggregation method chosen depends on the data
+rate required (and the maximum chunk size), the latency
+requirements, and the application semantics.
+
+Clearly, it is up to the implementation to decide how the data
+chunks are actually stored.  A sufficiently silly STuPiD server
+implementation might for instance use a MySQL database.
+
+
+== Security Considerations
+
+The security objectives of STuPiD are to be as secure as if
+NAT traversal had succeeded, i.e., an on-path attacker can
+overhear and fake messages, but an off-path attacker cannot.
+If a higher level of security is desired, it should be
+provided on top of the data relayed by STuPiD, e.g. by using
+XTLS <<I-D.meyer-xmpp-e2e-encryption>>.
+
+Much of the security of STuPiD is based on the assumption that
+an off-path attacker cannot guess the chunk identifiers.  A
+suitable source of randomness <<RFC4086>> should
+be used to generate at least a sufficiently large part of the
+chunk identifiers (e.g., the chunk identifier could be a hard
+to guess prefix followed by a serial number).
+
+To protect the STuPiD server against denial of service and
+possibly some forms of theft of service, it is **RECOMMENDED**
+that the POST side of the STuPiD server be protected by some
+form of authentication such as HTTP authentication.  There is
+little need to protect the GET side.
+
+[bibliography]
+== Normative References
+
+* [[[RFC2119,RFC 2119]]]
+* [[[RFC3986,RFC 3986]]]
+* [[[RFC4086,RFC 4086]]]
+* [[[RFC4648,RFC 4648]]]
+
+[bibliography]
+== Informative References
+
+* [[[RFC5389,RFC 5389]]]
+* [[[I-D.ietf-behave-turn,I-D.ietf-behave-turn]]]
+* [[[STUNT]]] Hanton, R., "STUNT & out-of-band channels", http://deusty.blogspot.com/2007/09/stunt-out-of-band-channels.html, September 2007.
+* [[[I-D.meyer-xmpp-e2e-encryption,I-D.meyer-xmpp-e2e-encryption]]]
+* [[[I-D.ietf-xmpp-3920bis,I-D.ietf-xmpp-3920bis]]]
+
+[#xmp]
+== Examples  
+
+This appendix provides some examples of the STuPiD protocol operation.
+
+[#figxmpdisco]
+.Discovering External IP Address and Port
+====
+....
+   Request:
+
+      GET /stupid.php HTTP/1.0
+      User-Agent: Example/1.11.4
+      Accept: */*
+      Host: example.org
+      Connection: Keep-Alive
+
+   Response:
+
+      HTTP/1.1 200 OK
+      Date: Sun, 05 Jul 2009 00:30:37 GMT
+      Server: Apache/2.2
+      Cache-Control: no-cache, must-revalidate
+      Expires: Sat, 26 Jul 1997 05:00:00 GMT
+      Vary: Accept-Encoding
+      Content-Length: 17
+      Keep-Alive: timeout=1, max=400
+      Connection: Keep-Alive
+      Content-Type: application/octet-stream
+
+      192.0.2.239:36654
+....
+====
+
+[#figxmpstore]
+.Storing Data
+====
+....
+   Request:
+
+      POST /stupid.php?chid=i781hf64-0 HTTP/1.0
+      User-Agent: Example/1.11.4
+      Accept: */*
+      Host: example.org
+      Connection: Keep-Alive
+      Content-Type: application/octet-stream
+      Content-Length: 11
+
+      Hello World
+
+   Response:
+
+      HTTP/1.1 200 OK
+      Date: Sun, 05 Jul 2009 00:20:34 GMT
+      Server: Apache/2.2
+      Cache-Control: no-cache, must-revalidate
+      Expires: Sat, 26 Jul 1997 05:00:00 GMT
+      Vary: Accept-Encoding
+      Content-Length: 0
+      Keep-Alive: timeout=1, max=400
+      Connection: Keep-Alive
+      Content-Type: application/octet-stream
+....
+====
+
+[#figxmpretr]
+.Retrieving Data
+====
+....
+   Request:
+
+      GET /stupid.php?chid=i781hf64-0 HTTP/1.0
+      User-Agent: Example/1.11.4
+      Accept: */*
+      Host: example.org
+      Connection: Keep-Alive
+
+   Response:
+
+      HTTP/1.1 200 OK
+      Date: Sun, 05 Jul 2009 00:21:29 GMT
+      Server: Apache/2.2
+      Cache-Control: no-cache, must-revalidate
+      Expires: Sat, 26 Jul 1997 05:00:00 GMT
+      Vary: Accept-Encoding
+      Content-Length: 11
+      Keep-Alive: timeout=1, max=400
+      Connection: Keep-Alive
+      Content-Type: application/octet-stream
+
+      Hello World
+....
+====
+
+[#impl]
+== Sample Implementation 
+
+[#figimpl]
+.STuPiD Sample Implementation
+====
+[source,php]
+----
+<?php
+header("Cache-Control: no-cache, must-revalidate");
+header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
+header("Content-Type: application/octet-stream");
+
+mysql_connect(localhost, "username", "password");
+mysql_select_db("stupid");
+
+$chid = mysql_real_escape_string($_GET["chid"]);
+
+if ($_SERVER["REQUEST_METHOD"] == "GET") {
+   if (empty($chid)) {
+      echo $_SERVER["REMOTE_ADDR"] . ":" . $_SERVER["REMOTE_PORT"];
+   } elseif ($result = mysql_query("SELECT `data` FROM `Data` " .
+                         "WHERE `chid` = '$chid'")) {
+      if ($row = mysql_fetch_array($result, MYSQL_ASSOC)) {
+         echo base64_decode($row["data"]);
+      } else {
+         header("HTTP/1.0 404 Not Found");
+      }
+      mysql_free_result($result);
+   } else {
+      header("HTTP/1.0 404 Not Found");
+   }
+} elseif ($_SERVER["REQUEST_METHOD"] == "POST") {
+   if (empty($chid)) {
+      header("HTTP/1.0 404 Not Found");
+   } else {
+      mysql_query("DELETE FROM `Data` " .
+                  "WHERE `timestamp` < DATE_SUB(NOW(), INTERVAL 5 MINUTE)");
+      $data = base64_encode(file_get_contents("php://input"));
+      if (!mysql_query("INSERT INTO `Data` (`chid`, `data`) " .
+                       "VALUES ('$chid', '$data')")) {
+         header("HTTP/1.0 403 Bad Request");
+      }
+   }
+} else {
+   header("HTTP/1.0 405 Method Not Allowed");
+   header("Allow: GET, HEAD, POST");
+}
+mysql_close();
+?>
+----
+====
+
+[#xmpp]
+== Using XMPP as Out-Of-Band Channel  
+
+XMPP <<I-D.ietf-xmpp-3920bis>> is a good choice for
+an out-of-band channel.
+
+The notification protocol is closely modeled after XMPP's
+In-Band Bytestreams (IBB, see
+\http://xmpp.org/extensions/xep-0047.html). Just replace the
+namespace and insert the STuPiD Retrieval URI instead of the
+actual Base64 encoded data, see <<figxmpnots>>.
+(Note that the current proposal redundantly sends a sid and a
+seq as well as the chid composed of these two; it may be
+possible to optimize this, possibly sending the constant prefix
+of the URI once at bytestream creation time.)
+
+Notifications **MUST** be processed in the order they are
+received. If an out-of-sequence notification is received for a
+particular session (determined by checking the 'seq' attribute),
+then this indicates that a notification has been lost. The
+recipient **MUST NOT** process such an out-of-sequence notification,
+nor any that follow it within the same session; instead, the
+recipient **MUST** consider the session invalid.  (Adapted from
+\http://xmpp.org/extensions/xep-0047.html#send)
+
+Of course, other methods can be used for setup and teardown, such as Jingle
+(see \http://xmpp.org/extensions/xep-0261.html).
+
+[#figxmpcri]
+.Creating a Bytestream: Initiator requests session
+====
+[source,xml]
+----
+      <iq from='romeo@montague.net/orchard'
+          id='jn3h8g65'
+          to='juliet@capulet.com/balcony'
+          type='set'>
+        <open xmlns='urn:xmpp:tmp:stupid'
+              block-size='65536'
+              sid='i781hf64'
+              stanza='iq'/>
+      </iq>
+----
+====
+
+[#figxmpcrr]
+.Creating a Bytestream: Responder accepts session
+====
+[source,xml]
+----
+      <iq from='juliet@capulet.com/balcony'
+          id='jn3h8g65'
+          to='romeo@montague.net/orchard'
+          type='result'/>
+----
+====
+
+[#figxmpnots]
+.Sending Notifications: Notification in an IQ stanza
+====
+[source,xml]
+----
+      <iq from='romeo@montague.net/orchard'
+          id='kr91n475'
+          to='juliet@capulet.com/balcony'
+          type='set'>
+        <data xmlns='urn:xmpp:tmp:stupid'
+              seq='0'
+              sid='i781hf64'
+              url='http://example.org/stupid.php?chid=i781hf64-0'/>
+      </iq>
+----
+====
+
+[#figxmpnota]
+.Sending Notifications: Acknowledging notification using IQ
+====
+[source,xml]
+----
+      <iq from='juliet@capulet.com/balcony'
+          id='kr91n475'
+          to='romeo@montague.net/orchard'
+          type='result'/>
+----
+====
+
+[#figxmpclor]
+.Closing the Bytestream: Request
+====
+[source,xml]
+----
+      <iq from='romeo@montague.net/orchard'
+          id='us71g45j'
+          to='juliet@capulet.com/balcony'
+          type='set'>
+        <close xmlns='urn:xmpp:tmp:stupid'
+               sid='i781hf64'/>
+      </iq>
+----
+====
+
+[#figxmpclos]
+.Closing the Bytestream: Success response
+====
+[source,xml]
+----
+      <iq from='juliet@capulet.com/balcony'
+          id='us71g45j'
+          to='romeo@montague.net/orchard'
+          type='result'/>
+----
+====
+
+


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-ietf/issues/233

The modernised heritage corpus from the #233 QA campaign: 21
documents (sources/<name>/document.adoc), each verified on the
released stack and through the campaign's three-surface harness.
Modernisation record and battery reports on the referenced issue.

🤖
