### PR TITLE
Enumerate the heritage corpus in the metanorma.yml manifest

### DIFF
--- a/metanorma.yml
+++ b/metanorma.yml
@@ -5,6 +5,28 @@ metanorma:
       #- sources/antioch/document.adoc
       - sources/example/document.adoc
       - sources/rfc-3339/document.adoc
+      # heritage corpus (mn-samples-ietf#58)
+      - sources/a/document.adoc
+      - sources/biblio-insert-v2/document.adoc
+      - sources/biblio-insert-v3/document.adoc
+      - sources/davies-template/document.adoc
+      - sources/draft-iab-html-rfc-bis/document.adoc
+      - sources/draft-iab-rfc-framework-bis/document.adoc
+      - sources/draft-ietf-core-block/document.adoc
+      - sources/example-v2/document.adoc
+      - sources/hoffmanv2/document.adoc
+      - sources/mib-doc-template/document.adoc
+      - sources/refs-v2/document.adoc
+      - sources/refs-v3/document.adoc
+      - sources/rfc1149/document.adoc
+      - sources/rfc2100/document.adoc
+      - sources/rfc3514/document.adoc
+      - sources/rfc5841/document.adoc
+      - sources/rfc6350/document.adoc
+      - sources/rfc748/document.adoc
+      - sources/rfc7511/document.adoc
+      - sources/skel/document.adoc
+      - sources/stupid-s/document.adoc
 
   collection:
     name: Metanorma-IETF sample documents

--- a/sources/a/document.adoc
+++ b/sources/a/document.adoc
@@ -7,6 +7,7 @@ A
 :fullname: A
 :surname: A
 :revdate: 2017-11-03
+:mn-document-class: ietf
 
 == Introduction
 

--- a/sources/biblio-insert-v2/document.adoc
+++ b/sources/biblio-insert-v2/document.adoc
@@ -5,6 +5,7 @@ Arthur Pendragon
 :fullname: Arthur Pendragon
 :surname: Pendragon
 :givenname: Arthur
+:mn-document-class: ietf
 
 [[xyz]]
 == Hello

--- a/sources/biblio-insert-v3/document.adoc
+++ b/sources/biblio-insert-v3/document.adoc
@@ -5,6 +5,7 @@ Arthur Pendragon
 :fullname: Arthur Pendragon
 :surname: Pendragon
 :givenname: Arthur
+:mn-document-class: ietf
 
 [[xyz]]
 == Hello

--- a/sources/davies-template/document.adoc
+++ b/sources/davies-template/document.adoc
@@ -24,6 +24,7 @@ Elwyn Davies <elwynd@dial.pipex.com>
 :compact: yes
 :subcompact: no
 :rfc2629xslt: true
+:mn-document-class: ietf
 
 Insert an abstract: MANDATORY. This template is for creating an
 Internet Draft.

--- a/sources/draft-iab-html-rfc-bis/document.adoc
+++ b/sources/draft-iab-html-rfc-bis/document.adoc
@@ -31,6 +31,7 @@ Joe Hildebrand <joe-ietf@cursive.net>; Paul Hoffman <paul.hoffman@icann.org>
 :email_2: paul.hoffman@icann.org
 :revdate: 2016-12
 :keyword: html,css,rfc
+:mn-document-class: ietf
 
 In order to meet the evolving needs of the Internet community, the
 canonical format for RFCs is changing from a plain-text, ASCII-only format to an

--- a/sources/draft-iab-rfc-framework-bis/document.adoc
+++ b/sources/draft-iab-rfc-framework-bis/document.adoc
@@ -18,6 +18,7 @@ Heather Flanagan <rse@rfc-editor.org>
 :area: General
 :workgroup: Internet Architecture Board
 :rfc2629xslt: true
+:mn-document-class: ietf
 
 
 The canonical format for the RFC Series has been plain-text, ASCII-encoded for several decades.  After extensive community discussion and debate, the RFC Editor will be transitioning to XML as the canonical format using the XML2RFC version 3 vocabulary. Different publication formats will be rendered from that base document.  These changes are intended to increase the usability of the RFC Series by offering documents that match the needs of a wider variety of stakeholders.  With these changes, however, comes an increase in complexity for authors, consumers, and the publisher of RFCs.  This document serves as the framework that describes the problems being solved and summarizes the many documents that capture the specific requirements for each aspect of the change in format.

--- a/sources/draft-ietf-core-block/document.adoc
+++ b/sources/draft-ietf-core-block/document.adoc
@@ -39,6 +39,7 @@ Carsten Bormann <cabo@tzi.org>; Zach Shelby <zach@sensinode.com>
 :inline-definition-lists: true
 :rfc2629xslt: true
 :compact: no
+:mn-document-class: ietf
 
 CoAP is a RESTful transfer protocol for constrained nodes and networks.
 Basic CoAP messages work well for the small payloads we expect

--- a/sources/example-v2/document.adoc
+++ b/sources/example-v2/document.adoc
@@ -33,6 +33,7 @@ David Waitzman <dwaitzman@BBN.COM>; Nick Nicholas <opoudjis@gmail.com>
 :city_2: Cambridge
 :code_2: MA 02238
 :contributor-uri_2: http://opoudjis.net
+:mn-document-class: ietf
 
 Avian carriers can provide high delay, low throughput, and low
 altitude service.  The connection topology is limited to a single

--- a/sources/hoffmanv2/document.adoc
+++ b/sources/hoffmanv2/document.adoc
@@ -40,6 +40,7 @@ Chris Smith <chrissmith@example.com>; Kim Jones <jk@lmn.op>
 :subcompact: no
 :strict: yes
 :rfc2629xslt: true
+:mn-document-class: ietf
 
 This is an example of an abstract.  It is a short paragraph that
 gives an overview of the document in order to help the reader

--- a/sources/mib-doc-template/document.adoc
+++ b/sources/mib-doc-template/document.adoc
@@ -26,6 +26,7 @@ Editor name <Editor email>
 :rfcedstyle: yes
 :comments: yes
 :inline: yes
+:mn-document-class: ietf
 
 [[CREF1: This template is for authors of IETF specifications containing MIB modules.  This template can be used as a starting point to produce specifications that comply with the Operations & Management Area guidelines for MIB module internet drafts. Throughout the template, the marker "[TEMPLATE TODO]" is used as a placeholder to indicate an element or text that requires replacement or removal. All the places with [TEMPLATE TODO] markers should be replaced or removed before the document is submitted.]]
 

--- a/sources/refs-v2/document.adoc
+++ b/sources/refs-v2/document.adoc
@@ -22,6 +22,7 @@ Simon Perreault <simon.perreault@viagenie.ca>
 :phone: +1 418 656 9254
 :uri: http://www.viagenie.ca
 :link: urn:issn:2070-1721 item
+:mn-document-class: ietf
 
 == Introduction
 The authors would like to thank Tim Howes, Mark Smith, and Frank

--- a/sources/refs-v3/document.adoc
+++ b/sources/refs-v3/document.adoc
@@ -31,6 +31,7 @@ Simon Perreault <simon.perreault@viagenie.ca>
 :code_2: MA 02238
 :uri_2: http://opoudjis.net
 :link: http://example1.com,http://example2.com author
+:mn-document-class: ietf
 
 == Introduction
 The authors would like to thank Tim Howes, Mark Smith, and Frank

--- a/sources/rfc1149/document.adoc
+++ b/sources/rfc1149/document.adoc
@@ -20,6 +20,7 @@ David Waitzman <dwaitzman@BBN.COM>
 :city: Cambridge
 :code: MA 02238
 :smart-quotes: false
+:mn-document-class: ietf
 
 [[overview-and-rational]]
 == Overview and Rational

--- a/sources/rfc2100/document.adoc
+++ b/sources/rfc2100/document.adoc
@@ -23,6 +23,7 @@ Jay R. Ashworth <jra@scfn.thpl.lib.fl.us>
 :sym-refs: false
 :toc-include: false
 :smart-quotes: false
+:mn-document-class: ietf
 
 
 [[introduction]]

--- a/sources/rfc3514/document.adoc
+++ b/sources/rfc3514/document.adoc
@@ -21,6 +21,7 @@ Steven M. Bellovin <bellovin@acm.org>
 :code: NJ 07932
 :smart-quotes: false
 :inline-definition-lists: true
+:mn-document-class: ietf
 
 Firewalls, packet filters, intrusion detection systems, and the like
 often have difficulty distinguishing between packets that have

--- a/sources/rfc5841/document.adoc
+++ b/sources/rfc5841/document.adoc
@@ -29,6 +29,7 @@ Richard Hay <rhay@google.com>; Warren Turkal <turkal@google.com>
 :street_2: 1600 Amphitheatre Pkwy
 :city_2: Mountain View
 :code_2: CA 94043
+:mn-document-class: ietf
 
 This document proposes a new TCP option to denote packet mood.
 

--- a/sources/rfc6350/document.adoc
+++ b/sources/rfc6350/document.adoc
@@ -27,6 +27,7 @@ Simon Perreault <simon.perreault@viagenie.ca>
 :ipr: pre5378Trust200902
 :inline-definition-lists: true
 :comments: yes
+:mn-document-class: ietf
 
 This document defines the vCard data format for representing and
 exchanging a variety of information about individuals and other

--- a/sources/rfc748/document.adoc
+++ b/sources/rfc748/document.adoc
@@ -15,6 +15,7 @@ M. Crispin
 :initials: M.
 :organization: SU-AI
 :smart-quotes: false
+:mn-document-class: ietf
 
 == Command name and code
 

--- a/sources/rfc7511/document.adoc
+++ b/sources/rfc7511/document.adoc
@@ -19,6 +19,7 @@ Maximilian Wilhelm <max@rfc2324.org>
 :city: Paderborn, NRW
 :country: Germany
 :smart-quotes: false
+:mn-document-class: ietf
 
 This document specifies a new routing scheme for the current version
 of the Internet Protocol version 6 (IPv6) in the spirit of "Green

--- a/sources/skel/document.adoc
+++ b/sources/skel/document.adoc
@@ -22,6 +22,7 @@ Carsten Bormann <cabo@tzi.org>
 :revdate: 2017-11-03
 :comments: yes
 :rfc2629xslt: true
+:mn-document-class: ietf
 
 insert abstract here
 

--- a/sources/stupid-s/document.adoc
+++ b/sources/stupid-s/document.adoc
@@ -32,6 +32,7 @@ Klaus Hartke <hartke@tzi.org>; Carsten Bormann <cabo@tzi.org>
 :phone_2: +49-421-218-63921
 :fax_2: +49-421-218-7000
 :rfc2629xslt: true
+:mn-document-class: ietf
 
 NAT (Network Address Translator) Traversal may require TURN
 (Traversal Using Relays around NAT) functionality in certain


### PR DESCRIPTION
Refs https://github.com/metanorma/mn-samples-ietf/pull/58

## Summary

Enumerates the 21 heritage-corpus documents (merged in #58) in `manifest.metanorma.source.files`. The manifest still listed only `sources/example` and `sources/rfc-3339`, so manifest-driven tooling — repo site-generate CI and the monthly cloud grammar census (`metanorma-cli` `grammar-census.yml`) — was blind to the entire heritage corpus.

`antioch` remains commented out, matching its pre-existing state.

Consequence: site-generate CI now builds all 21 additional documents. All compile clean against current metanorma-ietf (verified during the #233 QA campaign), so the cost is CI minutes, not breakage.

🤖
