### PR TITLE
Census authoring cleanup: revdate trims, body-clause stubs, draft docnumbers

### DIFF
--- a/sources/a/document.adoc
+++ b/sources/a/document.adoc
@@ -2,6 +2,7 @@
 A
 :doctype: internet-draft
 :name: draft-killer-rabbit-00
+:docnumber: draft-killer-rabbit-00
 :status: informational
 :intended-series: informational
 :fullname: A

--- a/sources/a/document.adoc
+++ b/sources/a/document.adoc
@@ -19,6 +19,11 @@ of all the creatures. Short of sanctified ordnance such as
 <<holy_hand_grenade,format=title>>, there are few remedies
 known against its awful lapine powers.
 
+== Discussion
+
+This clause exists so that the document body is not empty: the
+Metanorma grammar requires at least one body clause.
+
 [[holy_hand_grenade]]
 [bibliography]
 == Normative references

--- a/sources/biblio-insert-v2/document.adoc
+++ b/sources/biblio-insert-v2/document.adoc
@@ -1,6 +1,7 @@
 = The Holy Hand Grenade of Antioch
 Arthur Pendragon
 :doctype: internet-draft
+:docnumber: draft-biblio-insert-v2-00
 :workgroup: silly
 :fullname: Arthur Pendragon
 :surname: Pendragon

--- a/sources/biblio-insert-v3/document.adoc
+++ b/sources/biblio-insert-v3/document.adoc
@@ -1,6 +1,7 @@
 = The Holy Hand Grenade of Antioch
 Arthur Pendragon
 :doctype: internet-draft
+:docnumber: draft-biblio-insert-v3-00
 :workgroup: silly
 :fullname: Arthur Pendragon
 :surname: Pendragon

--- a/sources/davies-template/document.adoc
+++ b/sources/davies-template/document.adoc
@@ -2,6 +2,7 @@
 Elwyn Davies <elwynd@dial.pipex.com>
 :doctype: internet-draft
 :name: draft-ietf-xml2rfc-template-06
+:docnumber: draft-ietf-xml2rfc-template-06
 :ipr: trust200902
 :status: info
 :intended-series: informational

--- a/sources/draft-iab-rfc-framework-bis/document.adoc
+++ b/sources/draft-iab-rfc-framework-bis/document.adoc
@@ -2,6 +2,7 @@
 Heather Flanagan <rse@rfc-editor.org>
 :doctype: internet-draft
 :name: draft-iab-rfc-framework-06
+:docnumber: draft-iab-rfc-framework-06
 :status: informational
 :intended-series: informational
 :ipr: trust200902

--- a/sources/draft-ietf-core-block/document.adoc
+++ b/sources/draft-ietf-core-block/document.adoc
@@ -2,6 +2,7 @@
 Carsten Bormann <cabo@tzi.org>; Zach Shelby <zach@sensinode.com>
 :doctype: internet-draft
 :name: draft-ietf-core-block-05
+:docnumber: draft-ietf-core-block-05
 :revdate: 2012-01-13
 :ipr: trust200902
 :area: Applications

--- a/sources/example-v2/document.adoc
+++ b/sources/example-v2/document.adoc
@@ -12,7 +12,7 @@ David Waitzman <dwaitzman@BBN.COM>; Nick Nicholas <opoudjis@gmail.com>
 :area: Internet
 :workgroup: Network Working Group
 :keyword: this, that
-:revdate: 1990-04-01T00:00:00Z
+:revdate: 1990-04-01
 :fullname: David Waitzman
 :surname: Waitzman
 :givenname: David

--- a/sources/hoffmanv2/document.adoc
+++ b/sources/hoffmanv2/document.adoc
@@ -4,6 +4,7 @@ Chris Smith <chrissmith@example.com>; Kim Jones <jk@lmn.op>
 :status: standard
 :intended-series: standard
 :name: draft-example-of-xml-00
+:docnumber: draft-example-of-xml-00
 :ipr: trust200902
 :consensus: false
 :submission-type: IETF

--- a/sources/mib-doc-template/document.adoc
+++ b/sources/mib-doc-template/document.adoc
@@ -4,6 +4,7 @@ Editor name <Editor email>
 :status: historic
 :intended-series: historic
 :name: Your MIB Document name here rev07
+:docnumber: draft-mib-doc-template-07
 :ipr: trust200902
 :abbrev: Your MIB Module document name
 :fullname: Editor Name

--- a/sources/refs-v2/document.adoc
+++ b/sources/refs-v2/document.adoc
@@ -32,6 +32,11 @@ drafting, review, and discussion of this memo.
 <<RFC2119,RFC 2119>>
 <<RFC2119,format=counter: RFC 2119>>
 
+== Discussion
+
+This clause exists so that the document body is not empty: the
+Metanorma grammar requires at least one body clause.
+
 [bibliography]
 == Normative References
 

--- a/sources/refs-v3/document.adoc
+++ b/sources/refs-v3/document.adoc
@@ -43,6 +43,11 @@ drafting, review, and discussion of this memo:
 <<RFC2119,section=2.4>> 2
 <<RFC2119,section=2.4>> 3
 
+== Discussion
+
+This clause exists so that the document body is not empty: the
+Metanorma grammar requires at least one body clause.
+
 [bibliography]
 == Normative References
 

--- a/sources/refs-v3/document.adoc
+++ b/sources/refs-v3/document.adoc
@@ -12,7 +12,7 @@ Simon Perreault <simon.perreault@viagenie.ca>
 :area: Internet
 :workgroup: Network Working Group
 :keyword: this, that
-:revdate: 1990-04-01T00:00:00Z
+:revdate: 1990-04-01
 :fullname: Simon Perreault
 :surname: Perreault
 :givenname: Simon

--- a/sources/rfc1149/document.adoc
+++ b/sources/rfc1149/document.adoc
@@ -9,7 +9,7 @@ David Waitzman <dwaitzman@BBN.COM>
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 1990-04-01T00:00:00Z
+:revdate: 1990-04-01
 :fullname: David Waitzman
 :surname: Waitzman
 :givenname: David

--- a/sources/rfc2100/document.adoc
+++ b/sources/rfc2100/document.adoc
@@ -9,7 +9,7 @@ Jay R. Ashworth <jra@scfn.thpl.lib.fl.us>
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 1997-04-01T00:00:00Z
+:revdate: 1997-04-01
 :fullname: Jay R. Ashworth
 :surname: Ashworth
 :givenname: Jay

--- a/sources/rfc3514/document.adoc
+++ b/sources/rfc3514/document.adoc
@@ -5,6 +5,7 @@ Steven M. Bellovin <bellovin@acm.org>
 :status: info
 :intended-series: informational
 :name: rfc-3514
+:docnumber: 3514
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group

--- a/sources/rfc3514/document.adoc
+++ b/sources/rfc3514/document.adoc
@@ -8,7 +8,7 @@ Steven M. Bellovin <bellovin@acm.org>
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 2003-04-01T00:00:00Z
+:revdate: 2003-04-01
 :fullname: Steven M. Bellovin
 :surname: Bellovin
 :givenname: Steven

--- a/sources/rfc5841/document.adoc
+++ b/sources/rfc5841/document.adoc
@@ -9,7 +9,7 @@ Richard Hay <rhay@google.com>; Warren Turkal <turkal@google.com>
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 2010-04-01T00:00:00Z
+:revdate: 2010-04-01
 :fullname: Richard Hay
 :surname: Hay
 :givenname: Richard

--- a/sources/rfc748/document.adoc
+++ b/sources/rfc748/document.adoc
@@ -9,7 +9,7 @@ M. Crispin
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 1978-04-01T00:00:00Z
+:revdate: 1978-04-01
 :fullname: M. Crispin
 :surname: Crispin
 :initials: M.

--- a/sources/rfc7511/document.adoc
+++ b/sources/rfc7511/document.adoc
@@ -9,7 +9,7 @@ Maximilian Wilhelm <max@rfc2324.org>
 :ipr: trust200902
 :area: Internet
 :workgroup: Network Working Group
-:revdate: 2015-04-01T00:00:00Z
+:revdate: 2015-04-01
 :fullname: Maximilian Wilhelm
 :surname: Wilhelm
 :givenname: Maximilian

--- a/sources/skel/document.adoc
+++ b/sources/skel/document.adoc
@@ -29,6 +29,11 @@ insert abstract here
 
 This MAY <<RFC2119>> be useful.
 
+== Discussion
+
+This clause exists so that the document body is not empty: the
+Metanorma grammar requires at least one body clause.
+
 [bibliography]
 == Informative References
 

--- a/sources/skel/document.adoc
+++ b/sources/skel/document.adoc
@@ -3,6 +3,7 @@ Carsten Bormann <cabo@tzi.org>
 :doctype: internet-draft
 :abbrev: mfld
 :name: draft-mfld-00
+:docnumber: draft-mfld-00
 :status: informational
 :intended-series: informational
 :toc-include: yes

--- a/sources/stupid-s/document.adoc
+++ b/sources/stupid-s/document.adoc
@@ -3,6 +3,7 @@ Klaus Hartke <hartke@tzi.org>; Carsten Bormann <cabo@tzi.org>
 :doctype: internet-draft
 :abbrev: STuPiD
 :name: draft-hartke-xmpp-stupid-00
+:docnumber: draft-hartke-xmpp-stupid-00
 :revdate: 2009-07-05
 :status: informational
 :intended-series: informational


### PR DESCRIPTION
## Summary

Authoring-side cleanup from the 2026-08 grammar census, per the corpus owner's rulings:

- **:revdate: trims** (8 docs): conversion-artifact `T00:00:00Z` suffixes removed; the grammar's `date/on` is date-only.
- **Body-clause stubs** (4 docs: `a`, `skel`, `refs-v2`, `refs-v3`): these authored only an Introduction (which the IETF flavor places in the preface) plus bibliographies, leaving `<sections>` empty; the grammar requires at least one body clause. Each gains a self-documenting Discussion stub. In `a`, the stub is placed so the `[[holy_hand_grenade]]` anchor stays attached to the references section its `format=title` xref depends on.
- **:docnumber: authoring** (11 docs): sources emitting no bibdata `docidentifier` now author `:docnumber:`, following the corpus's own conventions (full draft name per the antioch precedent; bare number for RFC-heritage docs per rfc7511 et al.). Three values are newly coined where no `:name:` was derivable: `mib-doc-template`, `biblio-insert-v2`, `biblio-insert-v3`. This covers 11 docs against the census's count of 9 — the class is cleared, not just the reported instances.

Verified: `a` (which carries all change types) recompiles Syntax Valid, with a clause in `<sections>` and `<docidentifier primary="true">` emitted.

🤖
